### PR TITLE
downgrade munit plugin/update maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<app.name>salesforce-data-api</app.name>
 		<app.runtime>4.3.0</app.runtime>
-		<mule.maven.plugin.version>3.4.2</mule.maven.plugin.version>
+		<mule.maven.plugin.version>3.5.2</mule.maven.plugin.version>
 		<munit.version>2.2.5</munit.version>
 	</properties>
 


### PR DESCRIPTION
MUnit plugin version 2.3.5 was causing a missing dependency error. Downgraded to 2.2.5