### PR TITLE
added range choice to /all endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
 		<dependency>
 			<groupId>6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd</groupId>
 			<artifactId>salesforce-data-api</artifactId>
-			<version>3.0.23</version>
+			<version>3.0.24</version>
 			<classifier>raml</classifier>
 			<type>zip</type>
 		</dependency>

--- a/src/main/mule/salesforce-data-api.xml
+++ b/src/main/mule/salesforce-data-api.xml
@@ -3,7 +3,7 @@
     <http:listener-config name="salesforce-data-api-httpListenerConfig">
         <http:listener-connection host="${http.host}" port="${http.private.port}" />
     </http:listener-config>
-    <apikit:config name="salesforce-data-api-config" api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:3.0.23:raml:zip:salesforce-data-api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
+    <apikit:config name="salesforce-data-api-config" api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:3.0.24:raml:zip:salesforce-data-api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
     <salesforce:sfdc-config name="Salesforce_Config" doc:name="Salesforce Config" doc:id="012e809f-72bb-49a5-b21f-28fa4b364ab3">
         <salesforce:basic-connection username="${sfdc.user}" password="${sfdc.password}" securityToken="${sfdc.tkn}" url="${sfdc.url}" />
     </salesforce:sfdc-config>
@@ -252,15 +252,31 @@ payload map ( payload01 , indexOfPayload01 ) -> {
             </ee:variables>
         </ee:transform>
         <logger level="INFO" doc:name="Log Stored URI Params" doc:id="3d3be5d0-aed9-491c-94ae-1172c08100e3" message="URI Param - coachId: #[vars.coachId] - stored as vars" />
-        <salesforce:query doc:name="Query" doc:id="30344094-f0f1-44d4-bdc9-9897cbc2a741" config-ref="Salesforce_Config">
-            <salesforce:salesforce-query><![CDATA[SELECT Id,Name,Team__r.Name, Season__r.Name, Total_Number_of_Players__c, Team__r.School_Site__r.Region__c, (SELECT Id, Name, Session_Topic__c, Session_Date__c From Sessions__r WHERE Session_Date__c = :date),(SELECT Id,Contact__r.Name,Contact__r.FirstName,Contact__r.LastName,Contact__r.Birthdate,Contact__r.Gender__c,Contact__r.Ethnicity__c,Contact__r.Zip_First_Five_Digits__c,Contact__c From Enrollments__r) FROM Team_Season__c WHERE (Coach_Soccer__c = ':coachid' OR Coach_Writing__c = ':coachid' OR SCORES_Program_Coordinator__c = ':coachid' OR SCORES_Program_Manager__c = ':coachid') AND Season_Start_Date__c < :date AND Season_End_Date__c > :date]]></salesforce:salesforce-query>
-            <salesforce:parameters><![CDATA[#[output application/java
+        <choice doc:name="Choice" doc:id="3100b787-33bf-47c4-9eca-fd13cbb727db">
+            <when expression="#[attributes.queryParams.firstDate != null]">
+                <salesforce:query doc:name="Query with ranges" doc:id="f121388e-f35a-4eef-87be-f5bfdcd91479" config-ref="Salesforce_Config">
+                    <salesforce:salesforce-query><![CDATA[SELECT Id,Name,Team__r.Name, Season__r.Name, Total_Number_of_Players__c, Team__r.School_Site__r.Region__c, (SELECT Id, Name, Session_Topic__c, Session_Date__c From Sessions__r WHERE Session_Date__c >= :startDate AND Session_Date__c <= :endDate),(SELECT Id,Contact__r.Name,Contact__r.FirstName,Contact__r.LastName,Contact__r.Birthdate,Contact__r.Gender__c,Contact__r.Ethnicity__c,Contact__r.Zip_First_Five_Digits__c,Contact__c From Enrollments__r) FROM Team_Season__c WHERE (Coach_Soccer__c = ':coachid' OR Coach_Writing__c = ':coachid' OR SCORES_Program_Coordinator__c = ':coachid' OR SCORES_Program_Manager__c = ':coachid') AND Season_Start_Date__c < :startDate AND Season_End_Date__c > :startDate]]></salesforce:salesforce-query>
+                    <salesforce:parameters><![CDATA[#[output application/java
 ---
 {
-	date : attributes.queryParams.date,
+	endDate : attributes.queryParams.secondDate,
+	coachid : vars.coachId,
+	startDate : attributes.queryParams.firstDate
+}]]]></salesforce:parameters>
+                </salesforce:query>
+            </when>
+            <otherwise>
+                <salesforce:query doc:name="Query" doc:id="30344094-f0f1-44d4-bdc9-9897cbc2a741" config-ref="Salesforce_Config">
+                    <salesforce:salesforce-query><![CDATA[SELECT Id,Name,Team__r.Name, Season__r.Name, Total_Number_of_Players__c, Team__r.School_Site__r.Region__c, (SELECT Id, Name, Session_Topic__c, Session_Date__c From Sessions__r WHERE Session_Date__c = :date),(SELECT Id,Contact__r.Name,Contact__r.FirstName,Contact__r.LastName,Contact__r.Birthdate,Contact__r.Gender__c,Contact__r.Ethnicity__c,Contact__r.Zip_First_Five_Digits__c,Contact__c From Enrollments__r) FROM Team_Season__c WHERE (Coach_Soccer__c = ':coachid' OR Coach_Writing__c = ':coachid' OR SCORES_Program_Coordinator__c = ':coachid' OR SCORES_Program_Manager__c = ':coachid') AND Season_Start_Date__c < :date AND Season_End_Date__c > :date]]></salesforce:salesforce-query>
+                    <salesforce:parameters><![CDATA[#[output application/java
+---
+{
+	date : attributes.queryParams.firstDate,
 	coachid : vars.coachId
 }]]]></salesforce:parameters>
-        </salesforce:query>
+                </salesforce:query>
+            </otherwise>
+        </choice>
         <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="2e4560c3-3fd9-4697-9927-098a4fdc0436">
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
@@ -1452,7 +1468,7 @@ payload distinctBy (value) -> { "unique" : value }]]></ee:set-payload>
                 <ee:set-variable variableName="coachId"><![CDATA[attributes.uriParams.'coachId']]></ee:set-variable>
             </ee:variables>
         </ee:transform>
-		<salesforce:update type="Attendance__c" doc:name="Update" doc:id="4f4cb0a3-354a-4613-b2eb-8fc7789b795f" config-ref="Salesforce_Config">
+        <salesforce:update type="Attendance__c" doc:name="Update" doc:id="4f4cb0a3-354a-4613-b2eb-8fc7789b795f" config-ref="Salesforce_Config">
             <salesforce:records><![CDATA[#[%dw 2.0
 output application/java
 ---


### PR DESCRIPTION
added ranges choice to get/coach/coachid/all endpoint.
If only "firstDate" value is sent, endpoint retrieves sessions for the selected date.
If "firstDate" and "secondDate" parameters are entered, the endpoint retrieves all sessions within the date range input.