### PR TITLE
#195 `GET /contacts` Handle Missing Parameters (Throw 400 Error)

### DIFF
--- a/src/main/mule/contacts.xml
+++ b/src/main/mule/contacts.xml
@@ -402,7 +402,16 @@ payload.items[0].payload]]></ee:set-payload>
 				<ee:set-variable variableName="birthDate"><![CDATA[attributes.queryParams.'birthDate']]></ee:set-variable>
 			</ee:variables>
 		</ee:transform>
-		<choice
+        <choice doc:name="Choice" doc:id="kkvqoo" >
+			<when
+				 expression="#[(vars.firstName != null and vars.firstName != '' 
+				 				and vars.lastName != null and vars.lastName != '')
+								or 
+								(vars.externalStudentId != null and vars.externalStudentId != '' 
+								and 
+								vars.externalStudentIdSource != null and vars.externalStudentIdSource != '' )
+								]">
+			<choice
 			doc:name="Choice"
 			doc:id="d8bc290a-d74d-4841-828e-6faa4b57e36b">
 			<when
@@ -648,6 +657,23 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			doc:name="exit flow"
 			doc:id="17176b6b-a1c0-4851-984e-43b59c0506eb"
 			name="exit-flow" />
+			</when>
+            <otherwise>
+					<set-variable
+					variableName="httpStatus"
+					value="400"
+					doc:name="400 HTTP Status" />
+					<set-payload 
+					value="#[output application/json --- 
+					{
+						'error': 'Field Error',
+						'message': 'Either (externalStudentId and externalStudentIdSource) or (firstName and lastName) must be provided'
+					}]"
+					doc:name="Set Error Response" />
+					<raise-error type="GETCONTACT:BADREQUEST" doc:name="Raise Error" />
+			</otherwise>
+        </choice>
+		
 	</flow>
 	<flow name="get:\contacts\search:salesforce-data-api-config">
 		<flow-ref


### PR DESCRIPTION
**Description**:
This pull request adds validation to the `get/contacts` endpoint to ensure parameters are present. It throws a 400 error when either (`externalStudentId` and `externalStudentIdSource`) or both (`firstName` and `lastName`) are missing. Prior to this change, it would return 200 with an empty array.

**Example of 200 response:**
<img width="747" alt="image" src="https://github.com/AmericaSCORESBayArea/salesforce-data-api/assets/47938394/0d782673-20b6-4956-b2f8-bde774344ce2">

**Example of 400 response:**
<img width="931" alt="image" src="https://github.com/AmericaSCORESBayArea/salesforce-data-api/assets/47938394/6d955f31-79d9-4ddc-9158-cbc8d5a01fdb">


