### PR TITLE
Enable validation + add "details" field to 400 error response

### DIFF
--- a/src/main/mule/global.xml
+++ b/src/main/mule/global.xml
@@ -3,7 +3,7 @@
     <http:listener-config name="salesforce-data-api-httpListenerConfig">
         <http:listener-connection host="${http.host}" port="${http.private.port}" />
     </http:listener-config>
-    <apikit:config name="salesforce-data-api-config" api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:3.0.54:raml:zip:salesforce-data-api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" disableValidations="true" />
+    <apikit:config name="salesforce-data-api-config" api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:3.0.54:raml:zip:salesforce-data-api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" disableValidations="false" />
     <salesforce:sfdc-config name="Salesforce_Config" doc:name="Salesforce Config" doc:id="2a1bf2bd-81d6-4865-8976-cb3072a34787">
         <salesforce:basic-connection username="${sfdc.user}" password="${sfdc.password}" securityToken="${sfdc.tkn}" url="${sfdc.url}" />
     </salesforce:sfdc-config>

--- a/src/main/mule/main-api.xml
+++ b/src/main/mule/main-api.xml
@@ -16,9 +16,13 @@
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Bad request"}]]></ee:set-payload>
+                            output application/json
+                            ---
+                            {
+                                message: "Bad request",
+                                details: error.detailedDescription
+                            }]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">400</ee:set-variable>
@@ -29,9 +33,10 @@ output application/json
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Resource not found"}]]></ee:set-payload>
+                            output application/json
+                            ---
+                            {message: "Resource not found"}]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">404</ee:set-variable>
@@ -42,9 +47,10 @@ output application/json
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Method not allowed"}]]></ee:set-payload>
+                            output application/json
+                            ---
+                            {message: "Method not allowed"}]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">405</ee:set-variable>
@@ -55,9 +61,10 @@ output application/json
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Not acceptable"}]]></ee:set-payload>
+                            output application/json
+                            ---
+                            {message: "Not acceptable"}]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">406</ee:set-variable>
@@ -68,9 +75,12 @@ output application/json
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Unsupported media type"}]]></ee:set-payload>
+                            output application/json
+                            ---
+                            {
+                                    message: "Unsupported media type",
+                            }]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">415</ee:set-variable>
@@ -81,9 +91,10 @@ output application/json
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Not Implemented"}]]></ee:set-payload>
+                            output application/json
+                            ---
+                            {message: "Not Implemented"}]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">501</ee:set-variable>
@@ -94,9 +105,10 @@ output application/json
                 <ee:transform doc:name="Transform Message" doc:id="9bc7953f-4cbc-411c-9635-dc532f6bfdf5" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-payload]]></ee:set-payload>
+                            output application/json
+                            ---
+                            payload]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">409</ee:set-variable>
@@ -107,9 +119,10 @@ payload]]></ee:set-payload>
                 <ee:transform doc:name="Transform Message" doc:id="b39ada89-27d0-4d94-89cf-4560a5f8158a">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-payload.items.*payload]]></ee:set-payload>
+                            output application/json
+                            ---
+                            payload.items.*payload]]>
+                        </ee:set-payload>
                     </ee:message>
                 </ee:transform>
             </on-error-propagate>
@@ -131,9 +144,10 @@ payload.items.*payload]]></ee:set-payload>
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
                     <ee:message>
                         <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Resource not found"}]]></ee:set-payload>
+                            output application/json
+                            ---
+                            {message: "Resource not found"}]]>
+                        </ee:set-payload>
                     </ee:message>
                     <ee:variables>
                         <ee:set-variable variableName="httpStatus">404</ee:set-variable>
@@ -158,9 +172,10 @@ output application/json
         <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{message: "Not implemented yet"}]]></ee:set-payload>
+                    output application/json
+                    ---
+                    {message: "Not implemented yet"}]]>
+                </ee:set-payload>
             </ee:message>
             <ee:variables>
                 <ee:set-variable variableName="httpStatus">501</ee:set-variable>
@@ -176,11 +191,10 @@ output application/json
         <ee:transform>
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-  message: "Assessment updated"
-}]]></ee:set-payload>
+                        output application/json
+                        ---
+                        {message: "Assessment updated"}]]>
+                </ee:set-payload>
             </ee:message>
         </ee:transform>
     </flow>
@@ -193,11 +207,10 @@ output application/json
         <ee:transform>
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-  message: "bad request"
-}]]></ee:set-payload>
+                    output application/json
+                    ---
+                    { message: "bad request" }]]>
+                </ee:set-payload>
             </ee:message>
         </ee:transform>
     </flow>
@@ -210,11 +223,10 @@ output application/json
         <ee:transform>
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-  message: "Error retrieving enrollments"
-}]]></ee:set-payload>
+                    output application/json
+                    ---
+                    { message: "Error retrieving enrollments"
+                    }]]></ee:set-payload>
             </ee:message>
         </ee:transform>
     </flow>
@@ -228,11 +240,12 @@ output application/json
         <ee:transform>
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-  message: "Assessment updated"
-}]]></ee:set-payload>
+                    output application/json
+                    ---
+                    {
+                    message: "Assessment updated"
+                    }]]>
+                </ee:set-payload>
             </ee:message>
         </ee:transform>
     </flow>
@@ -245,11 +258,12 @@ output application/json
         <ee:transform>
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-  message: "Error retrieving enrollments"
-}]]></ee:set-payload>
+                    output application/json
+                    ---
+                    {
+                    message: "Error retrieving enrollments"
+                    }]]>
+                </ee:set-payload>
             </ee:message>
         </ee:transform>
     </flow>
@@ -265,11 +279,12 @@ output application/json
         <ee:transform>
             <ee:message>
                 <ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-  message: "assessment created"
-}]]></ee:set-payload>
+                    output application/json
+                    ---
+                    {
+                    message: "assessment created"
+                    }]]>
+                </ee:set-payload>
             </ee:message>
         </ee:transform>
     </flow>


### PR DESCRIPTION
**Description:**

Enabled validation based on the RAML file and included a detailed error description in "details" field for 400 error responses. Now, the server will return "Bad Request" if payload / parameters are missing. No extra error handling per flow is required anymore. 

Here is an example:

<img width="1039" alt="image" src="https://github.com/AmericaSCORESBayArea/salesforce-data-api/assets/47938394/83532b21-18ce-4b55-a9c3-f130069cd78b">

