### PR TITLE
Migrate to RAML 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd</groupId>
 			<artifactId>salesforce-data-api</artifactId>
-			<version>3.0.54</version>
+			<version>4.0.0</version>
 			<classifier>raml</classifier>
 			<type>zip</type>
 		</dependency>

--- a/src/main/mule/global.xml
+++ b/src/main/mule/global.xml
@@ -3,7 +3,7 @@
     <http:listener-config name="salesforce-data-api-httpListenerConfig">
         <http:listener-connection host="${http.host}" port="${http.private.port}" />
     </http:listener-config>
-    <apikit:config name="salesforce-data-api-config" api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:3.0.54:raml:zip:salesforce-data-api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" disableValidations="false" />
+    <apikit:config name="salesforce-data-api-config" api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:4.0.0:raml:zip:salesforce-data-api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" disableValidations="false" />
     <salesforce:sfdc-config name="Salesforce_Config" doc:name="Salesforce Config" doc:id="2a1bf2bd-81d6-4865-8976-cb3072a34787">
         <salesforce:basic-connection username="${sfdc.user}" password="${sfdc.password}" securityToken="${sfdc.tkn}" url="${sfdc.url}" />
     </salesforce:sfdc-config>


### PR DESCRIPTION
Updated RAML version from [3.0.54](https://anypoint.mulesoft.com/exchange/portals/americascores-bayarea/6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd/salesforce-data-api/minor/3.0/) to the latest [4.0.0](https://anypoint.mulesoft.com/exchange/portals/americascores-bayarea/6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd/salesforce-data-api/minor/4.0/).