### PR TITLE
Sandbox CI/CD: auto-deployment fix

### DIFF
--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -37,6 +37,19 @@ jobs:
            "username": "${{ secrets.anypoint_cicd_username }}",
            "password": "${{ secrets.anypoint_cicd_password }}"
           }]
+    - name: Insert Secret Properties to the .properties file
+      env:
+        SFDC_TKN: ${{ secrets.sfdc_tkn }}
+        SFDC_PASSWORD: ${{ secrets.sfdc_sandbox_integrationuser_pwd }}
+        TYPEFORM_CLIENTID: ${{ secrets.typeform_clientid }}
+        TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}
+        TYPEFORM_TKN: ${{ secrets.typeform_tkn }}
+      run: | 
+        sed -i 's/sfdc.tkn=/sfdc.tkn='${{ secrets.sfdc_tkn }}'/' properties/sandbox.properties
+        sed -i 's/sfdc.password=/sfdc.password='${{ secrets.sfdc_sandbox_integrationuser_pwd }}'/' properties/sandbox.properties
+        sed -i 's/typeform.clientid=/typeform.clientid='${{ secrets.typeform_clientid }}'/' properties/sandbox.properties
+        sed -i 's/typeform.clientsecret=/typeform.clientsecret='${{ secrets.typeform_clientsecret }}'/' properties/sandbox.properties
+        sed -i 's/typeform.tkn=/typeform.tkn='${{ secrets.typeform_tkn }}'/' properties/sandbox.properties
     - name: Print effective-settings
       run: mvn help:effective-settings
     - name: Print effective-pom

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -44,12 +44,18 @@ jobs:
         TYPEFORM_CLIENTID: ${{ secrets.typeform_clientid }}
         TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}
         TYPEFORM_TKN: ${{ secrets.typeform_tkn }}
-      run: | 
+      run: |
+        echo "Before replacing secrets:"
+        grep -E 'sfdc.tkn=|sfdc.password=|typeform.clientid=|typeform.clientsecret=|typeform.tkn=' src/main/resources/properties/sandbox.properties
+    
         sed -i "s/sfdc.tkn=/sfdc.tkn=${{ secrets.sfdc_tkn }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/sfdc.password=/sfdc.password=${{ secrets.sfdc_sandbox_integrationuser_pwd }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/typeform.clientid=/typeform.clientid=${{ secrets.typeform_clientid }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/typeform.clientsecret=/typeform.clientsecret=${{ secrets.typeform_clientsecret }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/typeform.tkn=/typeform.tkn=${{ secrets.typeform_tkn }}/" src/main/resources/properties/sandbox.properties
+    
+        echo "After replacing secrets:"
+        grep -E 'sfdc.tkn=|sfdc.password=|typeform.clientid=|typeform.clientsecret=|typeform.tkn=' src/main/resources/properties/sandbox.properties
     - name: Print effective-settings
       run: mvn help:effective-settings
     - name: Print effective-pom

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -55,11 +55,11 @@ jobs:
           exit 1
         fi
     
-        sed -i "s/sfdc.tkn=/sfdc.tkn=${{ secrets.sfdc_tkn }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/sfdc.tkn=/sfdc.tkn=${{ secrets.sfdc_sandbox_integrationuser_tkn }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/sfdc.password=/sfdc.password=${{ secrets.sfdc_sandbox_integrationuser_pwd }}/" src/main/resources/properties/sandbox.properties
-        sed -i "s/typeform.clientid=/typeform.clientid=${{ secrets.typeform.clientid }}/" src/main/resources/properties/sandbox.properties
-        sed -i "s/typeform.clientsecret=/typeform.clientsecret=${{ secrets.typeform.clientsecret }}/" src/main/resources/properties/sandbox.properties
-        sed -i "s/typeform.tkn=/typeform.tkn=${{ secrets.typeform.tkn }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.clientid=/typeform.clientid=${{ secrets.typeform_clientid }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.clientsecret=/typeform.clientsecret=${{ secrets.typeform_clientsecret }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.tkn=/typeform.tkn=${{ secrets.typeform_tkn }}/" src/main/resources/properties/sandbox.properties
     - name: Print effective-settings
       run: mvn help:effective-settings
     - name: Print effective-pom

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -80,6 +80,8 @@ jobs:
     - name: Setup tmate session
       if: success() || failure()
       uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: false
 
   deploy:
     needs: build

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -77,11 +77,6 @@ jobs:
       with:
           name: artifacts
           path: target/*.jar
-    - name: Setup tmate session
-      if: success() || failure()
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: false
 
   deploy:
     needs: build

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -4,9 +4,9 @@ name: Build and Deploy to Sandbox
 
 on:
   push:
-    branches: [ master ]
+    branches: [ sandbox ]
   workflow_dispatch:
-    branches: [ master ]
+    branches: [ sandbox ]
     
 jobs:
   build:

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -45,11 +45,11 @@ jobs:
         TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}
         TYPEFORM_TKN: ${{ secrets.typeform_tkn }}
       run: | 
-        sed -i 's/sfdc.tkn=/sfdc.tkn='${{ secrets.sfdc_tkn }}'/' properties/sandbox.properties
-        sed -i 's/sfdc.password=/sfdc.password='${{ secrets.sfdc_sandbox_integrationuser_pwd }}'/' properties/sandbox.properties
-        sed -i 's/typeform.clientid=/typeform.clientid='${{ secrets.typeform_clientid }}'/' properties/sandbox.properties
-        sed -i 's/typeform.clientsecret=/typeform.clientsecret='${{ secrets.typeform_clientsecret }}'/' properties/sandbox.properties
-        sed -i 's/typeform.tkn=/typeform.tkn='${{ secrets.typeform_tkn }}'/' properties/sandbox.properties
+        sed -i 's/sfdc.tkn=/sfdc.tkn='${{ secrets.sfdc_tkn }}'/' src/main/resources/properties/sandbox.properties
+        sed -i 's/sfdc.password=/sfdc.password='${{ secrets.sfdc_sandbox_integrationuser_pwd }}'/' src/main/resources/properties/sandbox.properties
+        sed -i 's/typeform.clientid=/typeform.clientid='${{ secrets.typeform_clientid }}'/' src/main/resources/properties/sandbox.properties
+        sed -i 's/typeform.clientsecret=/typeform.clientsecret='${{ secrets.typeform_clientsecret }}'/' src/main/resources/properties/sandbox.properties
+        sed -i 's/typeform.tkn=/typeform.tkn='${{ secrets.typeform_tkn }}'/' src/main/resources/properties/sandbox.properties
     - name: Print effective-settings
       run: mvn help:effective-settings
     - name: Print effective-pom

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -41,7 +41,7 @@ jobs:
       env:
         SFDC_TKN: ${{ secrets.sfdc_tkn }}
         SFDC_PASSWORD: ${{ secrets.sfdc_sandbox_integrationuser_pwd }}
-        TYPEFORM_CLIENTID: ${{ secrets.typeform.clientid }}
+        TYPEFORM_CLIENTID: ${{ secrets.typeform_clientid }}
         TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}
         TYPEFORM_TKN: ${{ secrets.typeform_tkn }}
       run: |

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -104,4 +104,4 @@ jobs:
         TYPEFORM_TKN: ${{ secrets.typeform_tkn }}
       run: |
         artifactName=$(ls *.jar | head -1)
-        mvn deploy -DmuleDeploy -e -Dmule.artifact=$artifactName -Danypoint.username="$USERNAME" -Danypoint.password="$PASSWORD" -Denv=Sandbox -Denv.lowercase=sandbox -Dsfdc.password="$SFDC_PASSWORD" -Dtypeform.clientid="$TYPEFORM_CLIENTID" -Dtypeform.clientsecret="$TYPEFORM_CLIENTSECRET" -Dtypeform.tkn="$TYPEFORM_TKN" -Dsfdc.tkn="$SFDC_TKN" -DskipTests
+        mvn deploy -DmuleDeploy -e -Dmule.artifact=$artifactName -Danypoint.username="$USERNAME" -Danypoint.password="$PASSWORD" -Denv=Sandbox -Denv.lowercase=sandbox -Dsfdc.password="$SFDC_SANDBOX_INTEGRATIONUSER_PWD" -Dtypeform.clientid="$TYPEFORM_CLIENTID" -Dtypeform.clientsecret="$TYPEFORM_CLIENTSECRET" -Dtypeform.tkn="$TYPEFORM_TKN" -Dsfdc.tkn="$SFDC_SANDBOX_INTEGRATIONUSER_TKN" -DskipTests

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -78,7 +78,7 @@ jobs:
           name: artifacts
           path: target/*.jar
     - name: Setup tmate session
-      if: failure()
+      if: success() || failure()
       uses: mxschmitt/action-tmate@v3
 
   deploy:

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -97,7 +97,7 @@ jobs:
       env:
         USERNAME: ${{ secrets.anypoint_cicd_username }}
         PASSWORD: ${{ secrets.anypoint_cicd_password }}
-        SFDC_TKN: ${{ secrets.sfdc_tkn }}
+        SFDC_TKN: ${{ secrets.sfdc_sandbox_integrationuser_tkn }}
         SFDC_PASSWORD: ${{ secrets.sfdc_sandbox_integrationuser_pwd }}
         TYPEFORM_CLIENTID: ${{ secrets.typeform_clientid }}
         TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -45,11 +45,11 @@ jobs:
         TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}
         TYPEFORM_TKN: ${{ secrets.typeform_tkn }}
       run: | 
-        sed -i 's/sfdc.tkn=/sfdc.tkn='${{ secrets.sfdc_tkn }}'/' src/main/resources/properties/sandbox.properties
-        sed -i 's/sfdc.password=/sfdc.password='${{ secrets.sfdc_sandbox_integrationuser_pwd }}'/' src/main/resources/properties/sandbox.properties
-        sed -i 's/typeform.clientid=/typeform.clientid='${{ secrets.typeform_clientid }}'/' src/main/resources/properties/sandbox.properties
-        sed -i 's/typeform.clientsecret=/typeform.clientsecret='${{ secrets.typeform_clientsecret }}'/' src/main/resources/properties/sandbox.properties
-        sed -i 's/typeform.tkn=/typeform.tkn='${{ secrets.typeform_tkn }}'/' src/main/resources/properties/sandbox.properties
+        sed -i "s/sfdc.tkn=/sfdc.tkn=${{ secrets.sfdc_tkn }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/sfdc.password=/sfdc.password=${{ secrets.sfdc_sandbox_integrationuser_pwd }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.clientid=/typeform.clientid=${{ secrets.typeform_clientid }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.clientsecret=/typeform.clientsecret=${{ secrets.typeform_clientsecret }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.tkn=/typeform.tkn=${{ secrets.typeform_tkn }}/" src/main/resources/properties/sandbox.properties
     - name: Print effective-settings
       run: mvn help:effective-settings
     - name: Print effective-pom

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -48,13 +48,12 @@ jobs:
         set -e  # Exit immediately if a command exits with a non-zero status
         echo "Checking if sandbox.properties file exists:"
         if [ -f src/main/resources/properties/sandbox.properties ]; then
-          echo "sandbox.properties file exists. Here is its content before replacing secrets:"
-          cat src/main/resources/properties/sandbox.properties
+          echo "sandbox.properties file exists."
         else
           echo "Error: sandbox.properties file does not exist."
           exit 1
         fi
-    
+  
         sed -i "s/sfdc.tkn=/sfdc.tkn=${{ secrets.sfdc_sandbox_integrationuser_tkn }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/sfdc.password=/sfdc.password=${{ secrets.sfdc_sandbox_integrationuser_pwd }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/typeform.clientid=/typeform.clientid=${{ secrets.typeform_clientid }}/" src/main/resources/properties/sandbox.properties

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -41,21 +41,25 @@ jobs:
       env:
         SFDC_TKN: ${{ secrets.sfdc_tkn }}
         SFDC_PASSWORD: ${{ secrets.sfdc_sandbox_integrationuser_pwd }}
-        TYPEFORM_CLIENTID: ${{ secrets.typeform_clientid }}
+        TYPEFORM_CLIENTID: ${{ secrets.typeform.clientid }}
         TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}
         TYPEFORM_TKN: ${{ secrets.typeform_tkn }}
       run: |
-        echo "Before replacing secrets:"
-        grep -E 'sfdc.tkn=|sfdc.password=|typeform.clientid=|typeform.clientsecret=|typeform.tkn=' src/main/resources/properties/sandbox.properties
+        set -e  # Exit immediately if a command exits with a non-zero status
+        echo "Checking if sandbox.properties file exists:"
+        if [ -f src/main/resources/properties/sandbox.properties ]; then
+          echo "sandbox.properties file exists. Here is its content before replacing secrets:"
+          cat src/main/resources/properties/sandbox.properties
+        else
+          echo "Error: sandbox.properties file does not exist."
+          exit 1
+        fi
     
         sed -i "s/sfdc.tkn=/sfdc.tkn=${{ secrets.sfdc_tkn }}/" src/main/resources/properties/sandbox.properties
         sed -i "s/sfdc.password=/sfdc.password=${{ secrets.sfdc_sandbox_integrationuser_pwd }}/" src/main/resources/properties/sandbox.properties
-        sed -i "s/typeform.clientid=/typeform.clientid=${{ secrets.typeform_clientid }}/" src/main/resources/properties/sandbox.properties
-        sed -i "s/typeform.clientsecret=/typeform.clientsecret=${{ secrets.typeform_clientsecret }}/" src/main/resources/properties/sandbox.properties
-        sed -i "s/typeform.tkn=/typeform.tkn=${{ secrets.typeform_tkn }}/" src/main/resources/properties/sandbox.properties
-    
-        echo "After replacing secrets:"
-        grep -E 'sfdc.tkn=|sfdc.password=|typeform.clientid=|typeform.clientsecret=|typeform.tkn=' src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.clientid=/typeform.clientid=${{ secrets.typeform.clientid }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.clientsecret=/typeform.clientsecret=${{ secrets.typeform.clientsecret }}/" src/main/resources/properties/sandbox.properties
+        sed -i "s/typeform.tkn=/typeform.tkn=${{ secrets.typeform.tkn }}/" src/main/resources/properties/sandbox.properties
     - name: Print effective-settings
       run: mvn help:effective-settings
     - name: Print effective-pom
@@ -73,6 +77,9 @@ jobs:
       with:
           name: artifacts
           path: target/*.jar
+    - name: Setup tmate session
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
 
   deploy:
     needs: build

--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -39,7 +39,7 @@ jobs:
           }]
     - name: Insert Secret Properties to the .properties file
       env:
-        SFDC_TKN: ${{ secrets.sfdc_tkn }}
+        SFDC_TKN: ${{ secrets.sfdc_sandbox_integrationuser_tkn }}
         SFDC_PASSWORD: ${{ secrets.sfdc_sandbox_integrationuser_pwd }}
         TYPEFORM_CLIENTID: ${{ secrets.typeform_clientid }}
         TYPEFORM_CLIENTSECRET: ${{ secrets.typeform_clientsecret }}

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <app.name>salesforce-data-api</app.name>
         <app.runtime>4.4.0</app.runtime>
-        <munit.version>2.3.6</munit.version>
+        <!-- <munit.version>2.3.6</munit.version> -->
         <mule.maven.plugin.version>4.0.0</mule.maven.plugin.version>
     </properties>
     <build>
@@ -48,7 +48,7 @@
                     </cloudHubDeployment>
                 </configuration>
             </plugin>
-            <plugin>
+            <!-- <plugin>
 				<groupId>com.mulesoft.munit.tools</groupId>
 				<artifactId>munit-maven-plugin</artifactId>
 				<version>${munit.version}</version>
@@ -78,7 +78,7 @@
 					</coverage>
 				</configuration>
 
-			</plugin>
+			</plugin> -->
         </plugins>
     </build>
     <dependencies>
@@ -119,7 +119,7 @@
             <version>10.18.3</version>
             <classifier>mule-plugin</classifier>
         </dependency>
-        <dependency>
+        <!-- <dependency>
 			<groupId>com.mulesoft.munit</groupId>
 			<artifactId>munit-tools</artifactId>
 			<version>2.3.14</version>
@@ -132,7 +132,7 @@
 			<version>2.3.14</version>
 			<classifier>mule-plugin</classifier>
 			<scope>test</scope>
-		</dependency>
+		</dependency> -->
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/resources/properties/production.properties
+++ b/src/main/resources/properties/production.properties
@@ -3,3 +3,9 @@ http.private.port=8091
 
 sfdc.user=integrationuser@americascores.org
 sfdc.url=https://americascoresbayarea.my.salesforce.com/services/Soap/u/48.0
+sfdc.tkn=
+sfdc.password=
+
+typeform.clientid=
+typeform.clientsecret=
+typeform.tkn=

--- a/src/main/resources/properties/sandbox.properties
+++ b/src/main/resources/properties/sandbox.properties
@@ -3,4 +3,9 @@ http.private.port=8091
 
 sfdc.user=integrationuser@americascores.org.scoresqa
 sfdc.url=https://americascoresbayarea--scoresqa.sandbox.my.salesforce.com/services/Soap/u/48.0
+sfdc.tkn=
+sfdc.password=
 
+typeform.clientid=
+typeform.clientsecret=
+typeform.tkn=


### PR DESCRIPTION
**Description:**

- [x] Comment out unnecessary dependencies (they break the built locally)
- [x] Added empty fields to the `.properties` files (to populate them on build)
- sfdc.tkn=
- sfdc.password=
- typeform.clientid=
- typeform.clientsecret=
- typeform.tkn=
- [x] Fixed the deployment workflow by inserting missing properties to the `sandbox.properties` file on build
- [x] Created `sandbox` branch and added protection rules similar to the `master` branch 
- [x] Switched push trigger from the `master` branch to the `sandbox` branch
- [x] Switched target branch from the `master` branch to the `sandbox` branch 