### PR TITLE
Include "Region" filter to contacts search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd</groupId>
             <artifactId>salesforce-data-api</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.3</version>
             <classifier>raml</classifier>
             <type>zip</type>
         </dependency>

--- a/src/main/mule/contacts.xml
+++ b/src/main/mule/contacts.xml
@@ -685,8 +685,19 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				<ee:set-variable variableName="searchString">
 					<![CDATA[attributes.queryParams.'searchString']]>
 				</ee:set-variable>
+				<ee:set-variable variableName="region">
+					<![CDATA[attributes.queryParams.'region']]>
+				</ee:set-variable>
 			</ee:variables>
 		</ee:transform>
+		<choice doc:name="Choice">
+           <when expression="#[isEmpty(vars.region)]">
+               <set-variable variableName="regionQueryCondition" value=""/>
+           </when>
+           <otherwise>	
+				<set-variable variableName="regionQueryCondition" value="#[' AND Region__c = \'' ++ (vars.region default '') ++ '\'']"/>
+           </otherwise>
+       </choice>
 		<salesforce:search doc:name="Search" doc:id="f195a55e-9140-44b5-b60e-1809649ef0a3" config-ref="Salesforce_Config">
 			<salesforce:search-string>
 				<![CDATA[
@@ -748,7 +759,8 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				Media_Release__c,
 				Data_Release__c 
 			WHERE 
-				Contact_Type__c = 'SCORES Student'
+				(Contact_Type__c = 'SCORES Student'
+				:regionQuery)
 			) 
 			LIMIT 8
 			]]>
@@ -757,7 +769,8 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				<![CDATA[#[output application/java
 ---
 {
-	searchString : vars.searchString
+	searchString : vars.searchString,
+	regionQuery : vars.regionQueryCondition
 }]]]>
 			</salesforce:parameters>
 		</salesforce:search>

--- a/src/main/mule/global.xml
+++ b/src/main/mule/global.xml
@@ -2,7 +2,7 @@
   <http:listener-config name="salesforce-data-api-httpListenerConfig">
     <http:listener-connection host="${http.host}" port="${http.private.port}"></http:listener-connection>
   </http:listener-config>
-  <apikit:config api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:4.0.2:raml:zip:salesforce-data-api.raml" disableValidations="false" httpStatusVarName="httpStatus" name="salesforce-data-api-config" outboundHeadersMapName="outboundHeaders"></apikit:config>
+  <apikit:config api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:4.0.3:raml:zip:salesforce-data-api.raml" disableValidations="false" httpStatusVarName="httpStatus" name="salesforce-data-api-config" outboundHeadersMapName="outboundHeaders"></apikit:config>
   <salesforce:sfdc-config doc:id="2a1bf2bd-81d6-4865-8976-cb3072a34787" doc:name="Salesforce Config" name="Salesforce_Config">
     <salesforce:basic-connection password="${sfdc.password}" securityToken="${sfdc.tkn}" url="${sfdc.url}" username="${sfdc.user}"></salesforce:basic-connection>
   </salesforce:sfdc-config>

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -261,6 +261,11 @@ uses:
           description: Search string
           type: string
           required: true
+        region:
+          displayName: region
+          description: Filter contacts by region
+          type: string
+          required: false
       responses:
         200:
           body:


### PR DESCRIPTION
**Description**:

Update `GET /contacts/search` to include `region`-based filter.

- [x] Added the endpoint to RAML
- [x] Implemented the API in seasons.xml
- [x] Updated Postman collection: /seasons/{seasonId}/teamSeasons
- [x] Included RAML change in Exchange and published it under 4.0.3

**Specification**:

*Endpoint*: `GET /contacts/search`

*Query Parameters*:

Name: searchString
Type: string
Required: true

Name: region
Type: string
Required: false

**Test example**:
`{{base_url}}/contacts/search?searchString=Angel`
`{{base_url}}/contacts/search?searchString=Angel&region=San Francisco Crocker`
`{{base_url}}/contacts/search?searchString=Angel&region=Hayward`

**Screenshots**:
<img width="703" alt="image" src="https://github.com/AmericaSCORESBayArea/salesforce-data-api/assets/47938394/89d9e6c3-91c2-4828-a16b-371cba6a2cd0">
<img width="703" alt="image" src="https://github.com/AmericaSCORESBayArea/salesforce-data-api/assets/47938394/c85535f9-0535-4189-9c6c-9dc7fedd8b0a">
<img width="703" alt="image" src="https://github.com/AmericaSCORESBayArea/salesforce-data-api/assets/47938394/fbe2d4c7-4643-4c24-9c07-28e9340a0d4a">

