### PR TITLE
NEW PROXY: Add HTTPS support

### DIFF
--- a/src/main/mule/global.xml
+++ b/src/main/mule/global.xml
@@ -1,13 +1,15 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:apikit="http://www.mulesoft.org/schema/mule/mule-apikit" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:api-gateway="http://www.mulesoft.org/schema/mule/api-gateway" xsi:schemaLocation=" http://www.mulesoft.org/schema/mule/mule-apikit http://www.mulesoft.org/schema/mule/mule-apikit/current/mule-apikit.xsd  http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/salesforce/current/mule-salesforce.xsd
-	http://www.mulesoft.org/schema/mule/api-gateway http://www.mulesoft.org/schema/mule/api-gateway/current/mule-api-gateway.xsd">
+	xmlns:api-gateway="http://www.mulesoft.org/schema/mule/api-gateway"
+	xmlns:tls="http://www.mulesoft.org/schema/mule/tls" xsi:schemaLocation=" http://www.mulesoft.org/schema/mule/mule-apikit http://www.mulesoft.org/schema/mule/mule-apikit/current/mule-apikit.xsd  http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/salesforce/current/mule-salesforce.xsd
+	http://www.mulesoft.org/schema/mule/api-gateway http://www.mulesoft.org/schema/mule/api-gateway/current/mule-api-gateway.xsd
+	http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd">
   <http:listener-config name="salesforce-data-api-httpListenerConfig">
-    <http:listener-connection host="${http.host}" port="${http.private.port}"></http:listener-connection>
+    <http:listener-connection host="${http.listener.host}" port="${http.listener.port}" tlsContext="tls-context" protocol="HTTPS"></http:listener-connection>
   </http:listener-config>
-  <apikit:config api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:4.0.3:raml:zip:salesforce-data-api.raml" disableValidations="false" httpStatusVarName="httpStatus" name="salesforce-data-api-config" outboundHeadersMapName="outboundHeaders"></apikit:config>
-  <salesforce:sfdc-config doc:id="2a1bf2bd-81d6-4865-8976-cb3072a34787" doc:name="Salesforce Config" name="Salesforce_Config">
+  <apikit:config api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:4.0.4:raml:zip:salesforce-data-api.raml" disableValidations="false" httpStatusVarName="httpStatus" name="salesforce-data-api-config" outboundHeadersMapName="outboundHeaders"></apikit:config>
+  <salesforce:sfdc-config doc:id="5f66efdc-67a7-42c7-97ef-430e32118489" doc:name="Salesforce Config" name="Salesforce_Config">
     <salesforce:basic-connection password="${sfdc.password}" securityToken="${sfdc.tkn}" url="${sfdc.url}" username="${sfdc.user}"></salesforce:basic-connection>
   </salesforce:sfdc-config>
-  <configuration-properties doc:id="8ea969ae-d401-4244-bc24-5799754cd4a3" doc:name="Configuration properties" file="properties/${env}.properties"></configuration-properties>
-  <api-gateway:autodiscovery apiId="${api.id}" ignoreBasePath="true" doc:name="API Autodiscovery" doc:id="db48c567-5713-4072-ba01-458941f5c8f1" flowRef="salesforce-data-api-main" />
+  <configuration-properties doc:id="0863edff-f537-40bd-b6de-0d5d7c3d55db" doc:name="Configuration properties" file="properties/${env}.properties"></configuration-properties>
+	<api-gateway:autodiscovery apiId="${api.id}" ignoreBasePath="true" doc:name="API Autodiscovery" doc:id="db48c567-5713-4072-ba01-458941f5c8f1" flowRef="salesforce-data-api-main" />
 </mule>

--- a/src/main/mule/tls-context.xml
+++ b/src/main/mule/tls-context.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:tls="http://www.mulesoft.org/schema/mule/tls"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd">
+
+    <tls:context name="tls-context">
+        <tls:key-store path="keystore.jks" keyPassword="${keystore.key.password}" password="${keystore.password}" />
+    </tls:context>
+
+</mule>


### PR DESCRIPTION
Enable HTTPS support by introducing [TLS-context](https://docs.mulesoft.com/http-connector/0.3.9/tls-configuration). CI/CD needs to be modified to generate `keystore.jks` with `keystore.key.password` and `keystore.password` properties. 