### PR TITLE
Local Run Support + Script To Build the App Locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Our MuleSoft app is built to interact with Scores data in Salesforce database. I
 
 [API Documentation](https://anypoint.mulesoft.com/exchange/portals/americascores-bayarea/6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd/salesforce-data-api/minor/3.0/console/summary/) (in review 🚧)
 
-[Postman Collection](https://github.com/AmericaSCORESBayArea/salesforce-data-api/blob/master/Scores%20-%20Salesforce%20Data%20API.postman_collection.json) (outdated 🚧)
+[Postman Collection](https://github.com/AmericaSCORESBayArea/salesforce-data-api/blob/master/docs/Scores%20-%20Salesforce%20Data%20API.postman_collection.json) (in progress 👨‍💻)
 
 [CloudHub Deployment](https://github.com/AmericaSCORESBayArea/salesforce-data-api/blob/master/cloudhub-deployment.md) (outdated 🚧)
 
@@ -103,3 +103,30 @@ Ta-da! You are now running the Mule app in the cloud-based environment. 🚀
     1. Go to [the Anypoint Code Builder dashboard](https://anypoint.mulesoft.com/codebuilder/)
     2. Select `Manage your IDE` option.
     3. Click on the `Reboot` button.
+
+
+## Build and Deployment
+The local build performed during the run differs from the build performed during the deployment. When running the app locally, `raml` files in local `src/main/resources/api` folder are used. When deploying the app, the `raml` files fetched from the Exchange are used. When building the app for deployment, the `global.xml.anypoint` should be used instead of `global.xml`. (handled by the `local-build.sh` script)
+
+To manually build the app for deployment, you need to execute the `local-build.sh` script. Then, you can manually upload the generated `.jar` file to CloudHub. Make sure the following properties are set in Mule Runtime secrets:
+
+```properties
+anypoint.platform.config.analytics.agent.enabled=
+anypoint.platform.client_id=
+anypoint.platform.client_secret=
+
+keystore.password=
+keystore.key.password=
+
+
+sfdc.password= 
+sfdc.tkn=
+
+typeform.clientsecret=
+typeform.clientid=
+typeform.tkn=
+
+api.id=
+
+env=
+```

--- a/local-build.sh
+++ b/local-build.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# This script is used to build the deployment package for the Mule application
+#
+# mvn needs to be installed in the environment to run this script
+# Arguments:
+# $1: keystore key password
+# $2: keystore password
+#
+# Author: Aleksandr Molchagin
+# Date: 2024-07-08
+
+#0. GET ARGUMENTS
+KEYSTORE_KEY_PASSWORD=${1:-password}
+KEYSTORE_PASSWORD=${2:-password}
+
+DIR="src/main/mule"
+
+# 1. RENAME FILES TO BUILD DEPLOYMENT PACKAGE
+if [ -f "$DIR/global.xml.anypoint" ]; then
+  # Rename global.xml to global.xml.local if it exists
+  if [ -f "$DIR/global.xml" ]; then
+    mv "$DIR/global.xml" "$DIR/global.xml.local"
+    echo "File 'global.xml' renamed to 'global.xml.local'."
+  fi
+
+  # Rename global.xml.anypoint to global.xml
+  mv "$DIR/global.xml.anypoint" "$DIR/global.xml"
+  echo "File 'global.xml.anypoint' renamed to 'global.xml'."
+else
+  echo "File 'global.xml.anypoint' does not exist."
+fi
+
+
+# 2. GENERATE KEYSTORE USING KEYTOOL
+keytool -genkeypair -keystore keystore.jks \
+  -dname "CN=localhost, OU=Unknown, O=America SCORES Bay Area, L=San Francisco, ST=California, C=US" \
+  -keypass $KEYSTORE_KEY_PASSWORD \
+  -storepass $KEYSTORE_PASSWORD \
+  -keyalg RSA \
+  -sigalg SHA1withRSA \
+  -keysize 2048 \
+  -alias mule \
+  -ext SAN=DNS:localhost,IP:127.0.0.1 \
+  -validity 9999
+mv keystore.jks src/main/resources
+
+#3. BUILD .JAR FILE
+echo "Building deployment package..."
+mvn -B package --file pom.xml
+
+
+#4. RENAME FILES BACK TO RUN IT LOCALLY
+if [ -f "$DIR/global.xml.local" ]; then
+  # Rename global.xml to global.xml.anypoint if it exists
+  if [ -f "$DIR/global.xml" ]; then
+    mv "$DIR/global.xml" "$DIR/global.xml.anypoint"
+    echo "File 'global.xml' renamed BACK to 'global.xml.anypoint'."
+  fi
+
+  # Rename global.xml.local to global.xml
+  mv "$DIR/global.xml.local" "$DIR/global.xml"
+  echo "File 'global.xml.local' renamed BACK to 'global.xml'."
+else
+  echo "File 'global.xml.local' does not exist."
+fi
+
+#5. APPEND LAST COMMIT HASH TO FILE
+
+if [ -z "$GITHUB_SHA" ]; then
+  echo "GITHUB_SHA is not set. Fetching the latest commit hash from git..."
+  LAST_COMMIT_HASH=$(git rev-parse --short HEAD)
+else
+  LAST_COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
+fi
+echo "The last commit hash on the current branch is: $LAST_COMMIT_HASH"
+mv "target/salesforce-data-api-1.0.0-SNAPSHOT-mule-application.jar" "target/salesforce-data-api-$LAST_COMMIT_HASH.jar"
+
+
+#6. IF MAC, OPEN TARGET FOLDER
+if [ "$(uname)" == "Darwin" ]; then
+  open ./target
+fi

--- a/src/main/mule/global.xml.anypoint
+++ b/src/main/mule/global.xml.anypoint
@@ -4,11 +4,13 @@
 	http://www.mulesoft.org/schema/mule/api-gateway http://www.mulesoft.org/schema/mule/api-gateway/current/mule-api-gateway.xsd
 	http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd">
   <http:listener-config name="salesforce-data-api-httpListenerConfig">
-        <http:listener-connection host="${http.listener.host}" port="${http.listener.port}"></http:listener-connection>
+    <http:listener-connection host="${http.listener.host}" port="${http.listener.port}" tlsContext="tls-context" protocol="HTTPS"></http:listener-connection>
   </http:listener-config>
-  <apikit:config api="salesforce-data-api.raml" disableValidations="false" httpStatusVarName="httpStatus" name="salesforce-data-api-config" outboundHeadersMapName="outboundHeaders"></apikit:config>
-  <salesforce:sfdc-config doc:id="5f66efdc-67a7-42c7-97ef-420e32118489" doc:name="Salesforce Config" name="Salesforce_Config">
+  
+  <apikit:config api="resource::6c091e72-50d1-49ac-b04d-ee5bb9bc9dbd:salesforce-data-api:4.0.4:raml:zip:salesforce-data-api.raml" disableValidations="false" httpStatusVarName="httpStatus" name="salesforce-data-api-config" outboundHeadersMapName="outboundHeaders"></apikit:config>
+  <salesforce:sfdc-config doc:id="5f66efdc-67a7-42c7-97ef-430e32118489" doc:name="Salesforce Config" name="Salesforce_Config">
     <salesforce:basic-connection password="${sfdc.password}" securityToken="${sfdc.tkn}" url="${sfdc.url}" username="${sfdc.user}"></salesforce:basic-connection>
   </salesforce:sfdc-config>
-  <configuration-properties doc:id="0863edff-f537-40bd-b6de-0d4d7c3d55db" doc:name="Configuration properties" file="properties/${env}.properties"></configuration-properties>
+  <configuration-properties doc:id="0863edff-f537-40bd-b6de-0d5d7c3d55db" doc:name="Configuration properties" file="properties/${env}.properties"></configuration-properties>
+	<api-gateway:autodiscovery apiId="${api.id}" ignoreBasePath="true" doc:name="API Autodiscovery" doc:id="db48c567-5713-4072-ba01-458941f5c8f1" flowRef="salesforce-data-api-main" />
 </mule>

--- a/src/main/resources/properties/production.properties
+++ b/src/main/resources/properties/production.properties
@@ -1,11 +1,5 @@
-http.host=0.0.0.0
-http.private.port=8091
+http.listener.host=0.0.0.0
+http.listener.port=8082
 
 sfdc.user=integrationuser@americascores.org
 sfdc.url=https://americascoresbayarea.my.salesforce.com/services/Soap/u/48.0
-sfdc.tkn=
-sfdc.password=
-
-typeform.clientid=
-typeform.clientsecret=
-typeform.tkn=

--- a/src/main/resources/properties/sandbox.properties
+++ b/src/main/resources/properties/sandbox.properties
@@ -1,11 +1,5 @@
-http.host=0.0.0.0
-http.private.port=8091
+http.listener.host=0.0.0.0
+http.listener.port=8082
 
 sfdc.user=integrationuser@americascores.org.scoresqa
 sfdc.url=https://americascoresbayarea--scoresqa.sandbox.my.salesforce.com/services/Soap/u/48.0
-sfdc.tkn=
-sfdc.password=
-
-typeform.clientid=
-typeform.clientsecret=
-typeform.tkn=


### PR DESCRIPTION
From now, the app can be run, developed and tested locally without applying any changes to `global.xml`.

Done:
- [x] Rename `global.xml` in `global.xml.anypoint` ( #260 will do the reverse when deploying)
- [x] Create `global.xml` that supports local run
- [ ] ~~Write a shell script that pulls secrets from GitHub and places them in local.properties~~
- [ ] ~~Write a shell script that runs the app without requiring the configuration of default arguments (or modify them)~~
- [x] Write a shell script that creates a deployment file ( 1) moves `global.xml.anypoint` -> `global.xml` 2) generates `keystore.jks` 3) builds the `salesforce-data-api-COMMIT-HASH.jar`
- [x] Update Readme

Notes:

1) Pulling secrets from GH is not possible, unless it is done through GitHub Actions
2) Modifying default arguments is still a requirement as we don't want overwrite all of them (Mulesoft might change them with updates) 
