### PR TITLE
Tasks: add `delete`, modify `get`

### DIFF
--- a/docs/Scores - Salesforce Data API.postman_collection.json
+++ b/docs/Scores - Salesforce Data API.postman_collection.json
@@ -184,9 +184,9 @@
 							}
 						],
 						"url": {
-							"raw": "{{base_url}}/teamSeasons?date=2019-01-01&endDate=2019-09-01&isWithinDateRange=true",
+							"raw": "{{base_url_s}}/teamSeasons?date=2024-01-01&endDate=2025-09-01&isWithinDateRange=true",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"teamSeasons"
@@ -194,11 +194,11 @@
 							"query": [
 								{
 									"key": "date",
-									"value": "2019-01-01"
+									"value": "2024-01-01"
 								},
 								{
 									"key": "endDate",
-									"value": "2019-09-01"
+									"value": "2025-09-01"
 								},
 								{
 									"key": "isWithinDateRange",
@@ -361,7 +361,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"TeamSeasonId\": \"\",\n  \"StudentId\": \"\",\n  \"StartDate\": \"\",\n  \"EndDate\": \"\"\n}",
+							"raw": "{\n  \"TeamSeasonId\": \"a0qUQ000003SRI5YAO\",\n  \"StudentId\": \"003cX000009kPO1QAM\",\n  \"StartDate\": \"2017-01-01\",\n  \"EndDate\": \"2018-01-01\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -369,9 +369,9 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/enrollments",
+							"raw": "{{base_url_s}}/enrollments",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"enrollments"
@@ -396,9 +396,9 @@
 							}
 						],
 						"url": {
-							"raw": "{{base_url}}/enrollments?teamSeasonId=a0q1T000008JoB4QAK",
+							"raw": "{{base_url_s}}/enrollments?teamSeasonId=a0q1T000008JoB4QAK",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"enrollments"
@@ -465,13 +465,13 @@
 							}
 						],
 						"url": {
-							"raw": "{{base_url}}/enrollments/a0m1T000008KwXkQAK",
+							"raw": "{{base_url_s}}/enrollments/a0qUQ000004TQpwYAG",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"enrollments",
-								"a0m1T000008KwXkQAK"
+								"a0qUQ000004TQpwYAG"
 							]
 						},
 						"description": "BODY/JSON:\n\n{  \n\"TeamSeasonName\": \"\",  \n\"TeamId\": \"\",  \n\"SeasonId\": \"\",  \n\"SchoolSite\": \"\",  \n\"Partnership\": \"\",  \n\"TotalNoOfPlayers\": 0,  \n\"TotalNoOfSessions\": 0,  \n\"SeasonStartDate\": \"\",  \n\"SeasonEndDate\": \"\",  \n\"CoachSoccer\": \"\",  \n\"CoachWriting\": \"\",  \n\"ProgramCoordinator\": \"\",  \n\"ProgramManager\": \"\"  \n}"
@@ -527,16 +527,16 @@
 						"header": [
 							{
 								"key": "client_id",
-								"value": "{{sandbox_client_id}}"
+								"value": "{{prod_client_id}}"
 							},
 							{
 								"key": "client_secret",
-								"value": "{{sandbox_client_secret}}"
+								"value": "{{prod_client_secret}}"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"FirstName\": \"\",\n  \"LastName\": \"\",\n  \"SchoolSiteId\": \"\"\n}",
+							"raw": "{\n  \"FirstName\": \"Aleksandr\",\n  \"LastName\": \"Testing On Nov 27\",\n  \"SchoolSiteId\": \"\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -544,9 +544,9 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/contacts",
+							"raw": "{{base_url_p}}/contacts",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_p}}"
 							],
 							"path": [
 								"contacts"
@@ -620,7 +620,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{base_url}}/contacts/search?searchString=John",
+							"raw": "{{base_url}}/contacts/search?searchString=Aleksandr",
 							"host": [
 								"{{base_url}}"
 							],
@@ -631,7 +631,7 @@
 							"query": [
 								{
 									"key": "searchString",
-									"value": "John"
+									"value": "Aleksandr"
 								}
 							]
 						},
@@ -688,13 +688,13 @@
 							}
 						],
 						"url": {
-							"raw": "{{base_url}}/contacts/003U8000008Mz3RIAS",
+							"raw": "{{base_url_s}}/contacts/003cX000009H3nWQAS",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"contacts",
-								"003U8000008Mz3RIAS"
+								"003cX000009H3nWQAS"
 							]
 						},
 						"description": "BODY/JSON:\n\n{  \n\"TeamSeasonName\": \"\",  \n\"TeamId\": \"\",  \n\"SeasonId\": \"\",  \n\"SchoolSite\": \"\",  \n\"Partnership\": \"\",  \n\"TotalNoOfPlayers\": 0,  \n\"TotalNoOfSessions\": 0,  \n\"SeasonStartDate\": \"\",  \n\"SeasonEndDate\": \"\",  \n\"CoachSoccer\": \"\",  \n\"CoachWriting\": \"\",  \n\"ProgramCoordinator\": \"\",  \n\"ProgramManager\": \"\"  \n}"
@@ -725,13 +725,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/contacts/003U8000008Mz3RIAS",
+							"raw": "{{base_url}}/contacts/003UQ00000GXyx3YAD",
 							"host": [
 								"{{base_url}}"
 							],
 							"path": [
 								"contacts",
-								"003U8000008Mz3RIAS"
+								"003UQ00000GXyx3YAD"
 							],
 							"query": [
 								{
@@ -788,9 +788,9 @@
 							}
 						],
 						"url": {
-							"raw": "{{base_url}}/contacts/003U8000008Mz3RIAS/enrollments",
+							"raw": "{{base_url_s}}/contacts/003U8000008Mz3RIAS/enrollments",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"contacts",
@@ -914,11 +914,31 @@
 					"name": "/sessions",
 					"request": {
 						"method": "POST",
-						"header": [],
+						"header": [
+							{
+								"key": "client_id",
+								"value": "{{sandbox_client_id}}",
+								"type": "text"
+							},
+							{
+								"key": "client_secret",
+								"value": "{{sandbox_client_secret}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"SessionDate\": \"2024-11-19\",\n    \"SessionTopic\": \"Game Day\",\n    \"TeamSeasonId\": \"a0qcX000000GEggQAG\",\n    \"SessionStart\": \"16:00:00.000Z\",\n    \"SessionEnd\": \"18:00:00.000Z\" \n  \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
-							"raw": "{{base_url}}/sessions",
+							"raw": "{{base_url_s}}/sessions",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"sessions"
@@ -954,15 +974,26 @@
 					"name": "/sessions/{sessionId}",
 					"request": {
 						"method": "GET",
-						"header": [],
+						"header": [
+							{
+								"key": "client_id",
+								"value": "{{sandbox_client_id}}",
+								"type": "text"
+							},
+							{
+								"key": "client_secret",
+								"value": "{{sandbox_client_secret}}",
+								"type": "text"
+							}
+						],
 						"url": {
-							"raw": "{{base_url}}/sessions/a0p1T00000FcFfGQAV",
+							"raw": "{{base_url_s}}/sessions/a0pcX0000008y3pQAA",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"sessions",
-								"a0p1T00000FcFfGQAV"
+								"a0pcX0000008y3pQAA"
 							],
 							"query": [
 								{
@@ -1642,7 +1673,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/tasks?contactId=003cX000008IZnXQAW",
+							"raw": "{{base_url}}/tasks?contactId=003cX000008IZnXQAW&sessionId=a0pcX0000008y3pQAA",
 							"host": [
 								"{{base_url}}"
 							],
@@ -1653,6 +1684,10 @@
 								{
 									"key": "contactId",
 									"value": "003cX000008IZnXQAW"
+								},
+								{
+									"key": "sessionId",
+									"value": "a0pcX0000008y3pQAA"
 								}
 							]
 						},
@@ -1676,7 +1711,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"AssignedBy\": \"\",\n    \"AssignedTo\": \"003cX000008IZnXQAW\",\n    \"CreatedByContact\": \"0051T000009eHfvQAE\",\n    \"CreatedContact\": \"\",\n    \"Description\": \"This is a test of the POST method #2.\",\n    \"DueDate\": \"2020-11-03\",\n    \"LastModifiedBy\": \"0051T000009eHfvQAE\",\n    \"LastModifiedContact\": \"\",\n    \"OwnerId\": \"0051T000009eHfvQAE\",\n    \"Priority\": 90.2,\n    \"ResourceLink\": \"\",\n    \"Session\": \"\",\n    \"Name\": \"Third task to do!\",\n    \"TaskStatus\": \"Complete\",\n    \"TaskType\": \"HR Requirement\" \n}",
+							"raw": "{\n    \"AssignedBy\": \"\",\n    \"AssignedTo\": \"003cX000008IZnXQAW\",\n    \"CreatedByContact\": \"0051T000009eHfvQAE\",\n    \"CreatedContact\": \"\",\n    \"Description\": \"This is a test of the a task with a session ID\",\n    \"DueDate\": \"2020-11-03\",\n    \"LastModifiedBy\": \"0051T000009eHfvQAE\",\n    \"LastModifiedContact\": \"\",\n    \"OwnerId\": \"0051T000009eHfvQAE\",\n    \"Priority\": 76.2,\n    \"ResourceLink\": \"\",\n    \"Session\": \"a0pcX0000008y3pQAA\",\n    \"Name\": \"Third task to do!\",\n    \"TaskStatus\": \"Complete\",\n    \"TaskType\": \"HR Requirement\" \n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1684,9 +1719,9 @@
 							}
 						},
 						"url": {
-							"raw": "{{base_url}}/tasks",
+							"raw": "{{base_url_s}}/tasks",
 							"host": [
-								"{{base_url}}"
+								"{{base_url_s}}"
 							],
 							"path": [
 								"tasks"
@@ -1727,6 +1762,43 @@
 							"path": [
 								"tasks",
 								"a40cX000000GcR7QAK"
+							]
+						},
+						"description": "BODY/JSON:\n\n{  \n\"TeamSeasonName\": \"\",  \n\"TeamId\": \"\",  \n\"SeasonId\": \"\",  \n\"SchoolSite\": \"\",  \n\"Partnership\": \"\",  \n\"TotalNoOfPlayers\": 0,  \n\"TotalNoOfSessions\": 0,  \n\"SeasonStartDate\": \"\",  \n\"SeasonEndDate\": \"\",  \n\"CoachSoccer\": \"\",  \n\"CoachWriting\": \"\",  \n\"ProgramCoordinator\": \"\",  \n\"ProgramManager\": \"\"  \n}"
+					},
+					"response": []
+				},
+				{
+					"name": "/tasks/{taskId}",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "client_id",
+								"value": "{{sandbox_client_id}}"
+							},
+							{
+								"key": "client_secret",
+								"value": "{{sandbox_client_secret}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"AssignedBy\": \"\",\n    \"AssignedTo\": \"003cX000008IZnXQAW\",\n    \"CreatedByContact\": \"0051T000009eHfvQAE\",\n    \"CreatedContact\": \"\",\n    \"Description\": \"This is a test of the POST method #2.\",\n    \"DueDate\": \"2020-11-03\",\n    \"LastModifiedBy\": \"0051T000009eHfvQAE\",\n    \"LastModifiedContact\": \"\",\n    \"OwnerId\": \"0051T000009eHfvQAE\",\n    \"Priority\": 90.2,\n    \"ResourceLink\": \"\",\n    \"Session\": \"\",\n    \"Name\": \"Third task to do!!\",\n    \"TaskStatus\": \"Complete\",\n    \"TaskType\": \"HR Requirement\" \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/tasks/a42cX000000GVPdQA2",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"a42cX000000GVPdQA2"
 							]
 						},
 						"description": "BODY/JSON:\n\n{  \n\"TeamSeasonName\": \"\",  \n\"TeamId\": \"\",  \n\"SeasonId\": \"\",  \n\"SchoolSite\": \"\",  \n\"Partnership\": \"\",  \n\"TotalNoOfPlayers\": 0,  \n\"TotalNoOfSessions\": 0,  \n\"SeasonStartDate\": \"\",  \n\"SeasonEndDate\": \"\",  \n\"CoachSoccer\": \"\",  \n\"CoachWriting\": \"\",  \n\"ProgramCoordinator\": \"\",  \n\"ProgramManager\": \"\"  \n}"

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -6,6 +6,24 @@
         <ee:set-variable variableName="contactId">
           <![CDATA[attributes.queryParams.'contactId']]>
         </ee:set-variable>
+		<ee:set-variable variableName="sessionId">
+          <![CDATA[attributes.queryParams.'sessionId']]>
+        </ee:set-variable>
+      </ee:variables>
+    </ee:transform>
+	  <ee:transform doc:id="7e56aada-f163-47f0-8ffc-213f3ecd09a8" doc:name="Prepare Query Condition">
+      <ee:variables>
+        <ee:set-variable variableName="query">
+			<![CDATA[
+				%dw 2.0
+				output application/json
+				---
+				if (vars.sessionId != null) 
+				"Assigned_To__c = '" ++ (vars.contactId default "") ++ "' AND Session__c = '" ++ (vars.sessionId default "") ++ "'"
+				else 
+				"Assigned_To__c = '" ++ (vars.contactId default "") ++ "'"
+			]]>
+        </ee:set-variable>
       </ee:variables>
     </ee:transform>
     <salesforce:query config-ref="Salesforce_Config" doc:id="1d085a1a-e15b-412b-a836-1014557a9abd" doc:name="Query to get tasks by contactId">
@@ -32,14 +50,14 @@
 				FROM 
 					SCORES_Task__c
 				WHERE 
-					Assigned_To__c = ':contactId'
-				]]>
+					:query
+			]]>
       </salesforce:salesforce-query>
       <salesforce:parameters>
         <![CDATA[#[output application/java
 				---
 				{
-					contactId : vars.contactId,
+					query: vars.query,
 				}
 			]]]>
       </salesforce:parameters>

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -6,15 +6,15 @@
         <ee:set-variable variableName="contactId">
           <![CDATA[attributes.queryParams.'contactId']]>
         </ee:set-variable>
-		<ee:set-variable variableName="sessionId">
+        <ee:set-variable variableName="sessionId">
           <![CDATA[attributes.queryParams.'sessionId']]>
         </ee:set-variable>
       </ee:variables>
     </ee:transform>
-	  <ee:transform doc:id="7e56aada-f163-47f0-8ffc-213f3ecd09a8" doc:name="Prepare Query Condition">
+    <ee:transform doc:id="7e56aada-f163-47f0-8ffc-213f3ecd09a8" doc:name="Prepare Query Condition">
       <ee:variables>
         <ee:set-variable variableName="query">
-			<![CDATA[
+          <![CDATA[
 				%dw 2.0
 				output application/json
 				---
@@ -149,21 +149,20 @@
     </ee:transform>
   </flow>
   <flow name="post:\tasks:application\json:salesforce-data-api-config">
-		<flow-ref doc:id="7d35fac9-4eff-49204-9840-1c046ef8a84a" doc:name="entry-flow" name="entry-flow"></flow-ref>
-		<ee:transform doc:id="d5391b37-613a-4aa1-8a95-31766e6f7b3ce" doc:name="Store payload">
-			<ee:variables>
-				<ee:set-variable variableName="originalPayload">
-												
-						<![CDATA[output application/json
+    <flow-ref doc:id="7d35fac9-4eff-49204-9840-1c046ef8a84a" doc:name="entry-flow" name="entry-flow"></flow-ref>
+    <ee:transform doc:id="d5391b37-613a-4aa1-8a95-31766e6f7b3ce" doc:name="Store payload">
+      <ee:variables>
+        <ee:set-variable variableName="originalPayload">
+          <![CDATA[output application/json
 							---
 							payload
-						]]>                    				
-				</ee:set-variable>
-			</ee:variables>
-		</ee:transform>
-		<salesforce:create config-ref="Salesforce_Config" doc:id="dd33ee35c-1b02-4cc9-a47b-733ddccb4800" doc:name="Create" type="SCORES_Task__c">
-              <salesforce:records>              							    
-				<![CDATA[#[output application/java
+						]]>
+        </ee:set-variable>
+      </ee:variables>
+    </ee:transform>
+    <salesforce:create config-ref="Salesforce_Config" doc:id="dd33ee35c-1b02-4cc9-a47b-733ddccb4800" doc:name="Create" type="SCORES_Task__c">
+      <salesforce:records>
+        <![CDATA[#[output application/java
 				---
 				[{
 					Assigned_To__c: vars.originalPayload.AssignedTo, // Mandatory field
@@ -180,70 +179,62 @@
 					(Task_Status__c: vars.originalPayload.TaskStatus) if vars.originalPayload.TaskStatus != null,
 					(Task_Type__c: vars.originalPayload.TaskType) if vars.originalPayload.TaskType != null
 				}]]]]>
-              </salesforce:records>
-        </salesforce:create>
-		<choice doc:name="Task creation successful?" doc:id="ee82b0c8-2c09-4456-a531a-80fba2c1e448">
-			<when expression="#[payload.items[0].successful == false]">
-				<ee:transform
-					doc:name="Create Error Response"
-					doc:id="aab7a4b8-dfff-46734-bf3e-acdbb63ea782">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
+      </salesforce:records>
+    </salesforce:create>
+    <choice doc:id="ee82b0c8-2c09-4456-a531a-80fba2c1e448" doc:name="Task creation successful?">
+      <when expression="#[payload.items[0].successful == false]">
+        <ee:transform doc:id="aab7a4b8-dfff-46734-bf3e-acdbb63ea782" doc:name="Create Error Response">
+          <ee:message>
+            <ee:set-payload>
+              <![CDATA[%dw 2.0
 						output application/json
 						---
 						{
 							message: payload.items[0].message
-						}]]></ee:set-payload>
-					</ee:message>
-						<ee:variables>
-							<ee:set-variable variableName="httpStatus"><![CDATA[400]]></ee:set-variable>
-						</ee:variables>
-						</ee:transform>
-					</when>
-					<otherwise>
-					<ee:transform
-						xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd"
-						doc:name="Create Response"
-						doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311">
-						<ee:message>
-							<ee:set-payload><![CDATA[%dw 2.0
+						}]]>
+            </ee:set-payload>
+          </ee:message>
+          <ee:variables>
+            <ee:set-variable variableName="httpStatus">
+              <![CDATA[400]]>
+            </ee:set-variable>
+          </ee:variables>
+        </ee:transform>
+      </when>
+      <otherwise>
+        <ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+          <ee:message>
+            <ee:set-payload>
+              <![CDATA[%dw 2.0
 								output application/json
 								---
 								{
 								TaskId: payload.items[0].id
 								}]]>
-							</ee:set-payload>
-						</ee:message>
-					</ee:transform>
-				</otherwise>
-		</choice>
-		<logger
-			level="INFO"
-			doc:name="Log Created Response"
-			doc:id="640a58eb-a8ab-40f9-bcc23-a9cadcf86bb5"
-			message="#[payload]" />
-		<flow-ref
-			doc:name="exit flow"
-			doc:id="ffed222e-011b-42f6-a9a1-2f3cb065c6e44"
-			name="exit-flow" />
+            </ee:set-payload>
+          </ee:message>
+        </ee:transform>
+      </otherwise>
+    </choice>
+    <logger doc:id="640a58eb-a8ab-40f9-bcc23-a9cadcf86bb5" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
+    <flow-ref doc:id="ffed222e-011b-42f6-a9a1-2f3cb065c6e44" doc:name="exit flow" name="exit-flow"></flow-ref>
   </flow>
-    <flow name="patch:\tasks\(taskId):application\json:salesforce-data-api-config">
-		<flow-ref doc:id="7d35fac9-4eff-49304-9840-1c046ef8a84a" doc:name="entry-flow" name="entry-flow"></flow-ref>
-		<set-variable value="#[attributes.uriParams.taskId]" doc:name="Set Task ID" variableName="taskId" doc:id="e1f7ebc1-0e1e-45b9-88b6-d6c5c998b79c"/>
-		<ee:transform doc:name="Store payload" doc:id="12345678-90ab-cdef-ghij-1234567890ab">
-			<ee:variables>
-				<ee:set-variable variableName="originalPayload">
-					<![CDATA[output application/json
+  <flow name="patch:\tasks\(taskId):application\json:salesforce-data-api-config">
+    <flow-ref doc:id="7d35fac9-4eff-49304-9840-1c046ef8a84a" doc:name="entry-flow" name="entry-flow"></flow-ref>
+    <set-variable doc:id="e1f7ebc1-0e1e-45b9-88b6-d6c5c998b79c" doc:name="Set Task ID" value="#[attributes.uriParams.taskId]" variableName="taskId"></set-variable>
+    <ee:transform doc:id="12345678-90ab-cdef-ghij-1234567890ab" doc:name="Store payload">
+      <ee:variables>
+        <ee:set-variable variableName="originalPayload">
+          <![CDATA[output application/json
 					---
 					payload
 					]]>
-				</ee:set-variable>
-			</ee:variables>
-		</ee:transform>
-
-		<salesforce:update config-ref="Salesforce_Config" doc:name="Update Task" doc:id="78901234-5678-90ab-cdef-567890abcdef" type="SCORES_Task__c">
-			<salesforce:records>
-				<![CDATA[#[output application/java
+        </ee:set-variable>
+      </ee:variables>
+    </ee:transform>
+    <salesforce:update config-ref="Salesforce_Config" doc:id="78901234-5678-90ab-cdef-567890abcdef" doc:name="Update Task" type="SCORES_Task__c">
+      <salesforce:records>
+        <![CDATA[#[output application/java
 				---
 				[{
 					Id: vars.taskId, // Mandatory ID field for updating record
@@ -261,56 +252,127 @@
 					(Task_Status__c: vars.originalPayload.TaskStatus) if vars.originalPayload.TaskStatus != null,
 					(Task_Type__c: vars.originalPayload.TaskType) if vars.originalPayload.TaskType != null
 				}]]]]>
-			</salesforce:records>
-		</salesforce:update>
-
-		<choice doc:name="Update Successful?" doc:id="abcdef12-3456-7890-abcd-ef1234567890">
-			<when expression="#[payload.items[0].successful == false]">
-				<ee:transform
-					doc:name="Create Error Response"
-					doc:id="abcd1234-5678-90ef-ghij-567890abcdef">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
+      </salesforce:records>
+    </salesforce:update>
+    <choice doc:id="abcdef12-3456-7890-abcd-ef1234567890" doc:name="Update Successful?">
+      <when expression="#[payload.items[0].successful == false]">
+        <ee:transform doc:id="abcd1234-5678-90ef-ghij-567890abcdef" doc:name="Create Error Response">
+          <ee:message>
+            <ee:set-payload>
+              <![CDATA[%dw 2.0
 						output application/json
 						---
 						{
 							message: payload.items[0].message
-						}]]></ee:set-payload>
-					</ee:message>
-					<ee:variables>
-						<ee:set-variable variableName="httpStatus"><![CDATA[400]]></ee:set-variable>
-					</ee:variables>
-				</ee:transform>
-			</when>
-			<otherwise>
-				<ee:transform
-					doc:name="Create Response"
-					doc:id="fedcba98-7654-3210-fedc-ba9876543210">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
+						}]]>
+            </ee:set-payload>
+          </ee:message>
+          <ee:variables>
+            <ee:set-variable variableName="httpStatus">
+              <![CDATA[400]]>
+            </ee:set-variable>
+          </ee:variables>
+        </ee:transform>
+      </when>
+      <otherwise>
+        <ee:transform doc:id="fedcba98-7654-3210-fedc-ba9876543210" doc:name="Create Response">
+          <ee:message>
+            <ee:set-payload>
+              <![CDATA[%dw 2.0
 						output application/json
 						---
 						{
 							message: "Task updated successfully",
 							TaskId: vars.taskId
 						}]]>
-						</ee:set-payload>
-					</ee:message>
-				</ee:transform>
-			</otherwise>
-		</choice>
-
-		<!-- Log Updated Response -->
-		<logger
-			level="INFO"
-			doc:name="Log Update Response"
-			doc:id="log12345-67890-abcdef-ghijk"
-			message="#[payload]" />
-
-		<!-- Exit Flow -->
-		<flow-ref
-			doc:name="exit flow"
-			doc:id="exit1234-5678-90ab-cdef-ghijklmno123"
-			name="exit-flow" />
+            </ee:set-payload>
+          </ee:message>
+        </ee:transform>
+      </otherwise>
+    </choice>
+    <!-- Log Updated Response -->
+    <logger doc:id="log12345-67890-abcdef-ghijk" doc:name="Log Update Response" level="INFO" message="#[payload]"></logger>
+    <!-- Exit Flow -->
+    <flow-ref doc:id="exit1234-5678-90ab-cdef-ghijklmno123" doc:name="exit flow" name="exit-flow"></flow-ref>
+  </flow>
+  <flow name="delete:\tasks\(taskId):salesforce-data-api-config">
+      <logger level="INFO" message="delete:\tasks\(taskId):salesforce-data-api-config"></logger>
+	  <set-variable variableName="taskId" value="#[attributes.uriParams.taskId]" doc:name="Set Task ID"></set-variable>
+	  <salesforce:query config-ref="Salesforce_Config" doc:id="1d085a1a-e15b-412b-a836-3014557a9abd" doc:name="Query to get tasks by contactId">
+      <salesforce:salesforce-query>
+        <![CDATA[
+				SELECT 
+					Id,
+					Assigned_By__c,
+					Assigned_To__c,
+					CreatedById,
+					Created_By_Contact__c,
+					Description__c,
+					Due_Date__c,
+					LastModifiedById,
+					Last_Modified_By_Contact__c,
+					OwnerId,
+					Priority__c,
+					Priority_Icon__c,
+					Resource_Link__c,
+					Session__c,
+					Name,
+					Task_Status__c,
+					Task_Type__c
+				FROM 
+					SCORES_Task__c
+				WHERE 
+					Id = ':taskId'
+			]]>
+      </salesforce:salesforce-query>
+      <salesforce:parameters>
+        <![CDATA[#[output application/java
+				---
+				{
+					taskId: vars.taskId,
+				}
+			]]]>
+      </salesforce:parameters>
+    </salesforce:query>
+        <choice doc:name="Choice" doc:id="pjptpt" >
+          <when expression='#[isEmpty(payload)]' doc:name="When" >
+			<ee:transform doc:name="Error response" doc:id="d4dc91ae-29b28-418d-9dfe-93075831d489" >
+				<ee:message >
+					<ee:set-payload ><![CDATA[%dw 2.0
+						output application/json
+						---
+						{
+							"message" : "Task doesn't exist. The deletion wasn't performed.",
+							"taskId": vars.taskId,
+						}]]></ee:set-payload>
+				</ee:message>
+			</ee:transform>
+				
+          </when>
+          <otherwise doc:name="Otherwise" >
+		          <salesforce:delete config-ref="Salesforce_Config" doc:name="Delete" doc:id="jfwsuu" >
+	<salesforce:ids>
+		<![CDATA[
+			#[output application/java
+				---
+				[vars.taskId]
+			]]]>
+		</salesforce:ids>
+    </salesforce:delete>
+	<ee:transform doc:id="fedcba98-7659-3210-fedc-ba9876543210" doc:name="Create Response">
+          <ee:message>
+            <ee:set-payload>
+              <![CDATA[%dw 2.0
+						output application/json
+						---
+						{
+							message: "Task deleted successfully.",
+							TaskId: vars.taskId
+						}]]>
+            </ee:set-payload>
+          </ee:message>
+        </ee:transform>
+          </otherwise>
+        </choice>
   </flow>
 </mule>

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -1080,6 +1080,10 @@ uses:
         description: The ID of the contact to retrieve tasks for
         type: string
         required: true
+      sessionId:
+        description: The ID of the session to retrieve tasks for
+        type: string
+        required: false
     responses:
       200:
         body:

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -1139,6 +1139,14 @@ uses:
             application/json:
               example:
                 message: Task updated
+    delete:
+      description: Delete a SCORES task
+      responses:
+        200:
+          body:
+            application/json:
+              example:
+                message: Task deleted successfully.
     /tags:
       get:
         description: Retrieve tags associated with a specific SCORES task


### PR DESCRIPTION
**1. GET {{base_url}}/tasks**
The `sessionId` parameter has been added as an optional filter to retrieve tasks associated with a specific session ID.
<img width="910" alt="image" src="https://github.com/user-attachments/assets/524e285b-c213-4989-b90a-22d8f8a813cd" />

**2. DELETE {{base_url}}/tasks/{taskId}**
Deletes a task based on its ID. A validation check is performed to ensure the existence of a valid task before deletion, preventing the removal of non-task objects.
<img width="910" alt="image" src="https://github.com/user-attachments/assets/1c5894ee-4b15-49dc-b0cd-b9777b1e21e8" />
