### PR TITLE
Sandbox: Update Remaining Error Handling Cases

### DIFF
--- a/src/main/mule/attendances.xml
+++ b/src/main/mule/attendances.xml
@@ -42,11 +42,10 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 					doc:name="Upsert successful?"
 					doc:id="033792a0-3de2-43bc-8b8e-e792264fa3eb">
 					<when
-						expression="#[(payload.items..*statusCode default []) contains 'UNABLE_TO_LOCK_ROW']">
-						<raise-error
-							doc:name="Raise error"
-							doc:id="31566e63-753c-4bae-9492-05a5ac7da221"
-							type="SALESFORCE-CUSTOM:UNABLE_TO_LOCK_ROW" />
+						expression="#[payload.successful == false]">
+						<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="be1b9699-37ed-4d17-96b7-3c400670cfea" variableName="errorCustomType" />
+						<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="1af6ccb4-8ef5-4b7e-b50a-dc286d8677be" variableName="errorCustomMessage" />
+						<raise-error doc:name="Raise error" doc:id="2494818a-ac68-43c1-931e-10c19593e6ef" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 					</when>
 				</choice>
 			</try>

--- a/src/main/mule/attendances.xml
+++ b/src/main/mule/attendances.xml
@@ -45,7 +45,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 						expression="#[payload.successful == false]">
 						<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="be1b9699-37ed-4d17-96b7-3c400670cfea" variableName="errorCustomType" />
 						<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="1af6ccb4-8ef5-4b7e-b50a-dc286d8677be" variableName="errorCustomMessage" />
-						<raise-error doc:name="Raise error" doc:id="2494818a-ac68-43c1-931e-10c19593e6ef" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+						<raise-error doc:name="Raise error" doc:id="2494818a-ac68-43c1-931e-10c19593e6ef" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating an attendance record." />
 					</when>
 				</choice>
 			</try>

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -589,7 +589,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="fcf6ce12-9747-44d5-a210-1bdf9a8e87c7" variableName="errorCustomType" />
 				<set-variable value='#[%dw 2.0&#10;output text/plain&#10;---&#10;(payload.items[0].message default "Error While Creating Attendances.") ++ &#10;(&#10;  payload.items map ((payload01, indexOfPayload01) -&gt; &#10;    " Message: " ++ write(payload01.payload default "", "application/json")&#10;  ) joinBy ""&#10;)]' doc:name="Set Custom Error Message" doc:id="d63cc331-c4c7-42ca-86b3-97f9ab84820f" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="0186bc58-0909-4a09-a760-10b16852fbec" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="0186bc58-0909-4a09-a760-10b16852fbec" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while updating an attendance record." />
 			</when>
 		</choice>
 		<logger
@@ -1193,7 +1193,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ATTENDANCE_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="de0127f1-9543-4247-98f0-4919cad5e132" variableName="errorCustomType" />
 				<set-variable value='#[%dw 2.0&#10;output text/plain&#10;---&#10;(payload.items[0].message default "Error While Updating Attendances.") ++ &#10;(&#10;  payload.items map ((payload01, indexOfPayload01) -&gt; &#10;    " Message: " ++ write(payload01.payload default "", "application/json")&#10;  ) joinBy ""&#10;)]' doc:name="Set Custom Error Message" doc:id="8d77c108-0e3c-4930-9f49-9734837df79c" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="a938155b-3242-4787-a33d-46ab6e9cdfaa" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="a938155b-3242-4787-a33d-46ab6e9cdfaa" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating an attendance record." />
 			</when>
 		</choice>
 		<ee:transform doc:name="Create Response" doc:id="fb3860fc-e16f-4661-ac7a-6df2a8cb4053" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
@@ -1254,7 +1254,7 @@ output application/json
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ASSESSMENT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="116d4fa4-38ec-4d54-aa7e-5a37736d91c3" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="69573011-d907-4da1-9113-f1eff05db828" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="2be38cb1-dd0f-47cc-be2f-6fa6cc505545" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="2be38cb1-dd0f-47cc-be2f-6fa6cc505545" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an assessment record." />
 			</when>
 		</choice>
 		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="aa2451bf-0b3f-4de0-9be9-fd354e65d674">

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1191,7 +1191,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 		</salesforce:update>
 		<choice doc:name="Update successful?" doc:id="81cab58f-3b0f-4844-9155-b03821c88f6f">
 			<when expression="#[payload.successful == false]">
-				<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="de0127f1-9543-4247-98f0-4919cad5e132" variableName="errorCustomType" />
+				<set-variable value="#['SALESFORCE_ATTENDANCE_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="de0127f1-9543-4247-98f0-4919cad5e132" variableName="errorCustomType" />
 				<set-variable value='#[%dw 2.0&#10;output text/plain&#10;---&#10;(payload.items[0].message default "Error While Updating Attendances.") ++ &#10;(&#10;  payload.items map ((payload01, indexOfPayload01) -&gt; &#10;    " Message: " ++ write(payload01.payload default "", "application/json")&#10;  ) joinBy ""&#10;)]' doc:name="Set Custom Error Message" doc:id="8d77c108-0e3c-4930-9f49-9734837df79c" variableName="errorCustomMessage" />
 				<raise-error doc:name="Raise error" doc:id="a938155b-3242-4787-a33d-46ab6e9cdfaa" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 			</when>

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -585,6 +585,13 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 	ExternalId__c: payload01.StudentId ++ '-' ++ vars.sessionId
 }]]]></salesforce:records>
 		</salesforce:upsert>
+		<choice doc:name="Upsert successful?" doc:id="ec201558-e363-41ba-90be-362ae01fbc41">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="fcf6ce12-9747-44d5-a210-1bdf9a8e87c7" variableName="errorCustomType" />
+				<set-variable value='#[%dw 2.0&#10;output text/plain&#10;---&#10;(payload.items[0].message default "Error While Creating Attendances.") ++ &#10;(&#10;  payload.items map ((payload01, indexOfPayload01) -&gt; &#10;    " Message: " ++ write(payload01.payload default "", "application/json")&#10;  ) joinBy ""&#10;)]' doc:name="Set Custom Error Message" doc:id="d63cc331-c4c7-42ca-86b3-97f9ab84820f" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="0186bc58-0909-4a09-a760-10b16852fbec" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+			</when>
+		</choice>
 		<logger
 			level="INFO"
 			doc:name="Log Upsert"
@@ -1182,31 +1189,14 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 	Attended__c: payload01.Attended,
 }]]]></salesforce:records>
 		</salesforce:update>
-		<choice
-			doc:name="Update successful?"
-			doc:id="3cf4d8b6-1188-40ca-af80-45874cd50d38">
-			<when expression="#[payload.items[0].successful == false]">
-				<ee:transform
-					doc:name="Create Error Response"
-					doc:id="52593c7f-e10a-4e17-89f4-17311b977136">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-	message: payload.items[0].message
-}]]></ee:set-payload>
-					</ee:message>
-					<ee:variables>
-						<ee:set-variable variableName="httpStatus"><![CDATA[400]]></ee:set-variable>
-					</ee:variables>
-				</ee:transform>
+		<choice doc:name="Update successful?" doc:id="81cab58f-3b0f-4844-9155-b03821c88f6f">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="de0127f1-9543-4247-98f0-4919cad5e132" variableName="errorCustomType" />
+				<set-variable value='#[%dw 2.0&#10;output text/plain&#10;---&#10;(payload.items[0].message default "Error While Updating Attendances.") ++ &#10;(&#10;  payload.items map ((payload01, indexOfPayload01) -&gt; &#10;    " Message: " ++ write(payload01.payload default "", "application/json")&#10;  ) joinBy ""&#10;)]' doc:name="Set Custom Error Message" doc:id="8d77c108-0e3c-4930-9f49-9734837df79c" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="a938155b-3242-4787-a33d-46ab6e9cdfaa" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 			</when>
-			<otherwise>
-				<ee:transform
-					doc:name="Create Response"
-					doc:id="fb3860fc-e16f-4661-ac7a-6df2a8cb4053"
-					xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+		</choice>
+		<ee:transform doc:name="Create Response" doc:id="fb3860fc-e16f-4661-ac7a-6df2a8cb4053" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -1216,13 +1206,7 @@ output application/json
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-			</otherwise>
-		</choice>
-		<logger
-			level="INFO"
-			doc:name="Log Created Response"
-			doc:id="6277debb-2aa4-4703-97d1-66d20cd0d8e0"
-			message="#[payload]" />
+		<logger level="INFO" doc:name="Log Created Response" doc:id="6277debb-2aa4-4703-97d1-66d20cd0d8e0" message="#[payload]" />
 	</flow>
 	<flow
 		name="post:\coach\(coachId)\teamseasons\(teamSeasonId)\sessions\(sessionId)\assessments:application\json:salesforce-data-api-config">
@@ -1266,31 +1250,14 @@ output application/json
 			doc:name="Create"
 			doc:id="b126f117-35b4-46a1-b69d-df1514f0915c"
 			config-ref="Salesforce_Config" />
-		<choice
-			doc:name="Assessment creation successful?"
-			doc:id="1c1e9ccb-357f-4ef7-8c80-10ce38ec8913">
-			<when expression="#[payload.items[0].successful == false]">
-				<ee:transform
-					doc:name="Create Error Response"
-					doc:id="7f75a24d-38cd-4ac0-b13a-3383a1bd303e">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-    message: payload.items[0].message
-}]]></ee:set-payload>
-					</ee:message>
-					<ee:variables>
-						<ee:set-variable variableName="httpStatus"><![CDATA[400]]></ee:set-variable>
-					</ee:variables>
-				</ee:transform>
+		<choice doc:name="Upsert successful?" doc:id="dfe49b47-2fee-468f-94de-a249c892f867">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_ASSESSMENT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="116d4fa4-38ec-4d54-aa7e-5a37736d91c3" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="69573011-d907-4da1-9113-f1eff05db828" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="2be38cb1-dd0f-47cc-be2f-6fa6cc505545" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 			</when>
-			<otherwise>
-				<ee:transform
-					xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd"
-					doc:name="Create Response"
-					doc:id="aa2451bf-0b3f-4de0-9be9-fd354e65d674">
+		</choice>
+		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="aa2451bf-0b3f-4de0-9be9-fd354e65d674">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -1300,8 +1267,6 @@ output application/json
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-			</otherwise>
-		</choice>
 		<logger
 			level="INFO"
 			doc:name="Log Created Response"
@@ -1327,7 +1292,7 @@ output application/json
 output application/json
 ---
 {
-  message: "Assessment updated"
+  message: "(not implemented)"
 }]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>

--- a/src/main/mule/contacts.xml
+++ b/src/main/mule/contacts.xml
@@ -1142,37 +1142,15 @@ output application/java
       </ee:message>
     </ee:transform>
     <salesforce:update config-ref="Salesforce_Config" doc:id="22d1f2d0-03bc-4987-82e8-200abcd9b67a" doc:name="Update" type="Contact"></salesforce:update>
-    <choice doc:id="61a478f2-2c8f-430b-a6ad-a5435c432f7a" doc:name="Update successful?">
-      <when expression="#[payload.items[0].successful == false]">
-        <ee:transform doc:id="7c3a7df0-eb2b-4a4d-9182-1fcfd74a48fb" doc:name="Transform Message">
-          <ee:message>
-            <ee:set-payload>
-                            							
-              
-              <![CDATA[%dw 2.0
-output application/json
----
-{
-	message: payload.items[0].message
-}]]>
-                            						
-            
-            </ee:set-payload>
-          </ee:message>
-          <ee:variables>
-            <ee:set-variable variableName="httpStatus">
-                            							
-              
-              <![CDATA[400]]>
-                            						
-            
-            </ee:set-variable>
-          </ee:variables>
-        </ee:transform>
-      </when>
-      <otherwise>
-        <flow-ref name="get:\contacts\(contactId):salesforce-data-api-config"></flow-ref>
-        <ee:transform doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+    <choice doc:name="Update successful?" doc:id="c09390f1-d74b-458c-8fec-c93ce0b08f8f">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_CONTACT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="7ad844ad-82d9-4148-9596-96f4a5f508b1" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="fd73d10f-89d1-4744-b11d-9c8e02b886d6" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="42cf2f5b-f5ef-4d5b-9ef5-6eae1595fb5e" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+			</when>
+		</choice>
+		<flow-ref name="get:\contacts\(contactId):salesforce-data-api-config"></flow-ref>
+		<ee:transform doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
           <ee:message>
             <ee:set-payload>
                             							
@@ -1189,9 +1167,7 @@ output application/json
             </ee:set-payload>
           </ee:message>
         </ee:transform>
-      </otherwise>
-    </choice>
-    <logger doc:id="07b47086-0cbc-4db9-9012-faaabb58cff9" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
+		<logger doc:id="07b47086-0cbc-4db9-9012-faaabb58cff9" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
   </flow>
   <flow doc:id="912d6ddf-b2bf-4f75-837a-21b1feccf869" name="get:\contacts\(contactId)\waiver\(waiverId):salesforce-data-api-config">
     <logger doc:id="c42d1dd4-9901-45ee-927f-9d59626fafc0" doc:name="Log entry-flow" level="INFO" message="Method and Request Path stored as vars: method=#[vars.method], request path=#[vars.requestPath]. queryparams=#[attributes.queryParams]"></logger>

--- a/src/main/mule/contacts.xml
+++ b/src/main/mule/contacts.xml
@@ -181,14 +181,6 @@ payload]]>
                 <logger doc:id="e9c02dd8-02dd-495d-8e01-b26db3d73ec2" doc:name="Logger" level="INFO" message="Fuzzy contact match found"></logger>
 				<set-variable doc:name="Set Custom Error Type" value="#['SALESFORCE_CONTACT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="3881f772-34d8-4c47-88d3-1aab40c248d1" variableName="errorCustomMessage" />
-								<choice doc:name="Choice" doc:id="68822a13-1319-472a-8858-780e4566d86d">
-									<when expression='#[vars.errorCustomType == "SALESFORCE_CONTACT_CREATE:DUPLICATES_DETECTED"]'>
-										<set-variable value="409" doc:name="Set Status Code" doc:id="03654d66-3aed-477e-88a3-e97dd843b1b3" variableName="httpStatus" />
-									</when>
-									<when expression='#[vars.errorCustomType == "SALESFORCE_CONTACT_CREATE:MALFORMED_ID"]'>
-										<set-variable value="400" doc:name="Set Status Code" doc:id="28d20a62-20e9-4298-8fb0-2c715fa266ef" variableName="httpStatus" />
-									</when>
-								</choice>
 								<raise-error doc:id="ce9837bc-7e7b-40a4-a132-7f35e82f12bc" doc:name="Raise error" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a contact. " />
               </when>
               <otherwise>
@@ -297,14 +289,6 @@ payload]]>
                 <logger doc:id="7179ab2b-5642-4f83-a3d6-ff4161272ef3" doc:name="Logger" level="INFO" message="Fuzzy contact match found"></logger>
 				<set-variable doc:name="Set Custom Error Type" value="#['SALESFORCE_CONTACT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="3881f772-34d8-4c47-88d3-1aab40c248d1" variableName="errorCustomMessage" />
-								<choice doc:name="Choice" doc:id="f7787813-3e7d-464d-8c06-e18f246213f9">
-							<when expression='#[vars.errorCustomType == "SALESFORCE_CONTACT_CREATE:DUPLICATES_DETECTED"]'>
-								<set-variable value="409" doc:name="Set Status Code" doc:id="796109aa-e4db-494c-b26c-b2bce9b90c44" variableName="httpStatus" />
-							</when>
-							<when expression='#[vars.errorCustomType == "SALESFORCE_CONTACT_CREATE:MALFORMED_ID"]'>
-								<set-variable value="400" doc:name="Set Status Code" doc:id="65f5844b-33d7-4253-b66f-550d08d48f3f" variableName="httpStatus" />
-							</when>
-						</choice>
 						<raise-error doc:id="ce9837bc-7e7b-40a4-a132-7f35e82f12bc" doc:name="Raise error" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a contact. " />
               </when>
               <otherwise>

--- a/src/main/mule/contacts.xml
+++ b/src/main/mule/contacts.xml
@@ -1146,7 +1146,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_CONTACT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="7ad844ad-82d9-4148-9596-96f4a5f508b1" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="fd73d10f-89d1-4744-b11d-9c8e02b886d6" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="42cf2f5b-f5ef-4d5b-9ef5-6eae1595fb5e" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="42cf2f5b-f5ef-4d5b-9ef5-6eae1595fb5e" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating a contact record." />
 			</when>
 		</choice>
 		<flow-ref name="get:\contacts\(contactId):salesforce-data-api-config"></flow-ref>

--- a/src/main/mule/enrollments.xml
+++ b/src/main/mule/enrollments.xml
@@ -246,31 +246,14 @@ output application/java
 			doc:name="Update"
 			doc:id="db1b614e-3b4c-4db6-8195-a6e9617257e4"
 			config-ref="Salesforce_Config" />
-		<choice
-			doc:name="Update successful?"
-			doc:id="eb93d985-08a5-4d18-8f5b-9597673b2a24">
-			<when expression="#[payload.items[0].successful == false]">
-				<ee:transform
-					doc:name="Create Error Response"
-					doc:id="36abc3b2-f428-48ee-b518-a1353e6f235a">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-	message: payload.items[0].message
-}]]></ee:set-payload>
-					</ee:message>
-					<ee:variables>
-						<ee:set-variable variableName="httpStatus"><![CDATA[400]]></ee:set-variable>
-					</ee:variables>
-				</ee:transform>
+		<choice doc:name="Update successful?" doc:id="24b97665-02fd-4dec-bbf7-285f710ea489">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_ENROLLMENT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="b9040877-1f5b-4788-a786-b5384e68f239" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="7c6fec7f-dbc4-46a3-917a-183fd5bc796b" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="844ccc3d-6ada-4719-aa14-1fad90ea1000" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 			</when>
-			<otherwise>
-				<ee:transform
-					xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd"
-					doc:name="Create Response"
-					doc:id="5cd8fa6a-e3d1-44de-9625-aff048e5fc8f">
+		</choice>
+		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="5cd8fa6a-e3d1-44de-9625-aff048e5fc8f">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -280,8 +263,6 @@ output application/json
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-			</otherwise>
-		</choice>
 		<logger
 			level="INFO"
 			doc:name="Log Created Response"

--- a/src/main/mule/enrollments.xml
+++ b/src/main/mule/enrollments.xml
@@ -250,7 +250,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ENROLLMENT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="b9040877-1f5b-4788-a786-b5384e68f239" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="7c6fec7f-dbc4-46a3-917a-183fd5bc796b" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="844ccc3d-6ada-4719-aa14-1fad90ea1000" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="844ccc3d-6ada-4719-aa14-1fad90ea1000" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating an enrollment record." />
 			</when>
 		</choice>
 		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="5cd8fa6a-e3d1-44de-9625-aff048e5fc8f">
@@ -297,7 +297,7 @@ output application/java
 			<when expression="#[payload.items[0].successful == false]">
 				<set-variable value="#['SALESFORCE_ENROLLMENT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="d5c68077-bb4c-4245-b6c5-68396295759c" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="f52e5839-b9ee-4a28-8944-62b63c974bc6" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="20ccb42b-2476-402d-a634-7c7ae8243959" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a contact. " />
+				<raise-error doc:name="Raise error" doc:id="20ccb42b-2476-402d-a634-7c7ae8243959" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating an enrollment record. " />
 			</when>
 			<otherwise>
 				<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="291c1936-dfea-4dd5-aaba-c30a5a5b4311">

--- a/src/main/mule/main-api.xml
+++ b/src/main/mule/main-api.xml
@@ -14,7 +14,7 @@
 		<apikit:router config-ref="salesforce-data-api-config" />
         <flow-ref doc:name="Log Response" doc:id="553e8f82-198b-4c48-829e-7117c3c7634d" name="exit-flow"/>
 		<error-handler>
-			<on-error-propagate enableNotifications="true" logException="true" doc:name="On Error Propagate" doc:id="a0f1f919-7033-446f-be52-c49a7341cb34" type="APIKIT:BAD_REQUEST, CUSTOM:BAD_REQUEST">
+			<on-error-propagate enableNotifications="true" logException="true" doc:name="On Error Propagate" doc:id="a0f1f919-7033-446f-be52-c49a7341cb34" type="APIKIT:BAD_REQUEST, CUSTOM:BAD_REQUEST, SALESFORCE:INVALID_INPUT">
 				<ee:transform doc:name="Transform Message" doc:id="9e09454e-d82f-4a26-854e-16807ca0c340">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
@@ -203,7 +203,7 @@
 	                            message: "An unknown error occurred",
 	                            error: (error.description default ""),
 	                            detailedError: (error.detailedDescription default ""),
-	                            errorType: "Global Error Handler: " ++ (error.errorType.namespace default "") ++ ":" ++ (error.errorType.identifier default "")
+	                            errorType: "UNKNOWN:" ++ (error.errorType.namespace default "") ++ ":" ++ (error.errorType.identifier default "")
                             }
                             ]]></ee:set-payload>
 					</ee:message>

--- a/src/main/mule/main-api.xml
+++ b/src/main/mule/main-api.xml
@@ -24,7 +24,8 @@
 	                            message: "Invalid Request Format",
 	                            error: (error.description default ""),
 	                            detailedError: (error.detailedDescription default ""),
-	                            errorType: (error.errorType.namespace default "") ++ ":" ++ (error.errorType.identifier default "")
+	                            errorType: (error.errorType.namespace default "") ++ ":" ++ (error.errorType.identifier default ""),
+	                            errorSource: (error.dslSource  default "")
                             }
                             ]]></ee:set-payload>
 					</ee:message>
@@ -254,11 +255,11 @@
                                            ++ "*Error Type:* " ++ (vars.errorPayload.errorType default "N/A") ++ "\n"
 						                   ++ "*Error Message:* " ++ (vars.errorPayload.error default "N/A") ++ "\n"
 						                   ++ "*Detailed Error Description:* " ++ (vars.errorPayload.detailedError default "N/A") ++ "\n"
-						                   ++ "*Source:* " ++ (error.dslSource default "N/A")
+						                   ++ "*Source:* " ++ (vars.errorPayload.errorSource default "N/A")
 						                   ++ (
 						                       if (!isEmpty(vars.originalPayload)) 
 						                       "\n*Payload Attached:* ```" ++ (write(vars.originalPayload, "application/json") default "No payload available") ++ "```"
-						                       else ""
+						                       else "\n*Payload Attached:* No payload attached."
 					                   		)
 				                   }
 				            	}

--- a/src/main/mule/main-api.xml
+++ b/src/main/mule/main-api.xml
@@ -168,6 +168,14 @@
 				<flow-ref doc:name="Flow Reference: Slack" doc:id="4b9c6834-bdea-4c69-8ea9-233bae3a559c" name="global-error-handler" />
 			</on-error-propagate>
             <on-error-propagate enableNotifications="true" logException="true" doc:name="On Error Propagate" doc:id="67896d39-b9c7-4032-9762-8194362c31d7" type="CUSTOM:CUSTOM_ERROR">
+				<choice doc:name="Choice" doc:id="1c191d29-1312-4e97-a1a9-f5d37d8be49a">
+					<when expression='#[vars.errorCustomType contains "DUPLICATES_DETECTED"]'>
+						<set-variable value="409" doc:name="Set Status Code" doc:id="ce66e384-6022-462c-ba5e-342621113bb5" variableName="httpStatus" />
+					</when>
+					<when expression='#[vars.errorCustomType contains "MALFORMED_ID"]'>
+						<set-variable value="400" doc:name="Set Status Code" doc:id="51fbd79f-5402-4a83-8ca3-b8680e3b81e0" variableName="httpStatus" />
+					</when>
+				</choice>
 				<ee:transform doc:name="Transform Message" doc:id="e7421cb1-862d-4dc7-bbee-e8ab29f998fe">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0

--- a/src/main/mule/main-api.xml
+++ b/src/main/mule/main-api.xml
@@ -169,11 +169,13 @@
 			</on-error-propagate>
             <on-error-propagate enableNotifications="true" logException="true" doc:name="On Error Propagate" doc:id="67896d39-b9c7-4032-9762-8194362c31d7" type="CUSTOM:CUSTOM_ERROR">
 				<choice doc:name="Choice" doc:id="1c191d29-1312-4e97-a1a9-f5d37d8be49a">
-					<when expression='#[vars.errorCustomType contains "DUPLICATES_DETECTED"]'>
+					<when expression='#[(vars.errorCustomType contains "DUPLICATES_DETECTED") or (vars.errorCustomMessage contains "DUPLICATES_DETECTED" )]'>
 						<set-variable value="409" doc:name="Set Status Code" doc:id="ce66e384-6022-462c-ba5e-342621113bb5" variableName="httpStatus" />
+						<set-variable value='#[vars.errorCustomType replace "UNKNOWN" with "DUPLICATES_DETECTED"]' doc:name="Update errorCustomType" doc:id="fa24b860-a1da-478a-8fcb-4c209b129de7" variableName="errorCustomType" />
 					</when>
-					<when expression='#[vars.errorCustomType contains "MALFORMED_ID"]'>
+					<when expression='#[(vars.errorCustomType contains "MALFORMED_ID") or (vars.errorCustomMessage contains "MALFORMED_ID" )]'>
 						<set-variable value="400" doc:name="Set Status Code" doc:id="51fbd79f-5402-4a83-8ca3-b8680e3b81e0" variableName="httpStatus" />
+						<set-variable value='#[vars.errorCustomType replace "UNKNOWN" with "MALFORMED_ID"]' doc:name="Update errorCustomType" doc:id="5049dfed-7516-4f02-b8b1-b273863b706b" variableName="errorCustomType"/>
 					</when>
 				</choice>
 				<ee:transform doc:name="Transform Message" doc:id="e7421cb1-862d-4dc7-bbee-e8ab29f998fe">

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -191,7 +191,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_SESSION_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="9fbbe3a1-79b5-4f6d-800f-8beadaaad609" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="2f5302d7-ac4c-4e32-883c-ab45aa802497" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="fb063b28-d382-4f8f-b234-d2f6ff1e150e" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="fb063b28-d382-4f8f-b234-d2f6ff1e150e" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating a session record." />
 			</when>
 		</choice>
 		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="e4941d73-e82e-40a0-b233-d8ab1b1563c2">
@@ -242,7 +242,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_SESSION_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="80d0ee96-1184-465b-a512-34155d33db9d" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="6e50136b-e978-4594-9c21-44076456a2e9" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="c6e24563-2fc9-426c-bc46-6955bc1d402b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="c6e24563-2fc9-426c-bc46-6955bc1d402b" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a session record." />
 			</when>
 		</choice>
 		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="6779c4d0-a8dc-4e33-befa-a4b77df09562">

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -187,31 +187,14 @@ output application/java
 			doc:name="Update"
 			doc:id="8c8e7dd2-d781-47cf-86ea-22b015e314d3"
 			config-ref="Salesforce_Config" />
-		<choice
-			doc:name="Update successful?"
-			doc:id="02923d83-7d61-4a29-98cc-02e7ebd9c287">
-			<when expression="#[payload.items[0].successful == false]">
-				<ee:transform
-					doc:name="Create Error Response"
-					doc:id="92521a9b-a8a5-4f91-ac00-166310c64545">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-	message: payload.items[0].message
-}]]></ee:set-payload>
-					</ee:message>
-					<ee:variables>
-						<ee:set-variable variableName="httpStatus"><![CDATA[400]]></ee:set-variable>
-					</ee:variables>
-				</ee:transform>
+		<choice doc:name="Update successful?" doc:id="f4c85f06-f54f-497d-b69b-9007eb30e2f0">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_SESSION_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="9fbbe3a1-79b5-4f6d-800f-8beadaaad609" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="2f5302d7-ac4c-4e32-883c-ab45aa802497" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="fb063b28-d382-4f8f-b234-d2f6ff1e150e" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 			</when>
-			<otherwise>
-				<ee:transform
-					xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd"
-					doc:name="Create Response"
-					doc:id="e4941d73-e82e-40a0-b233-d8ab1b1563c2">
+		</choice>
+		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="e4941d73-e82e-40a0-b233-d8ab1b1563c2">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -221,8 +204,6 @@ output application/json
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-			</otherwise>
-		</choice>
 		<logger
 			level="INFO"
 			doc:name="Log Created Response"
@@ -257,31 +238,14 @@ output application/java
 			doc:name="Create"
 			doc:id="b3d05b31-6ff5-4009-8e65-d5e947bf452c"
 			config-ref="Salesforce_Config" />
-		<choice
-			doc:name="Session creation successful?"
-			doc:id="08fb00d4-b2b7-4713-b742-8f985875bb70">
-			<when expression="#[payload.items[0].successful == false]">
-				<ee:transform
-					doc:name="Create Error Response"
-					doc:id="bab61664-0548-4e6c-aeb9-c2801cc89ff2">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-	message: payload.items[0].message
-}]]></ee:set-payload>
-					</ee:message>
-					<ee:variables>
-						<ee:set-variable variableName="httpStatus"><![CDATA[400]]></ee:set-variable>
-					</ee:variables>
-				</ee:transform>
+		<choice doc:name="Update successful?" doc:id="5ea52270-6369-44a8-aaef-22ec7832b131">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_SESSION_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="80d0ee96-1184-465b-a512-34155d33db9d" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="6e50136b-e978-4594-9c21-44076456a2e9" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="c6e24563-2fc9-426c-bc46-6955bc1d402b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 			</when>
-			<otherwise>
-				<ee:transform
-					xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd"
-					doc:name="Create Response"
-					doc:id="6779c4d0-a8dc-4e33-befa-a4b77df09562">
+		</choice>
+		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="6779c4d0-a8dc-4e33-befa-a4b77df09562">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -291,8 +255,6 @@ output application/json
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-			</otherwise>
-		</choice>
 		<logger
 			level="INFO"
 			doc:name="Log Created Response"

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -184,7 +184,7 @@
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_TASK_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="f249a0dc-5aa0-4602-8892-7d3f88d9803e" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="981e406e-d3b3-40ef-a6eb-ed275aefe119" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="140608b5-54cf-46b4-bb71-72fc3936666b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="140608b5-54cf-46b4-bb71-72fc3936666b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
 			</when>
 		</choice>
     <ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
@@ -240,7 +240,7 @@
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_TASK_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="ccedeaca-059e-42c7-a1f1-7e366f3491a8" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="2a56b6a0-da4b-42be-8724-c1d6755eed24" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="72edbd97-752e-404a-a756-3b0f5fa9d27b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="72edbd97-752e-404a-a756-3b0f5fa9d27b" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating a task record." />
 			</when>
 		</choice>
 		<ee:transform doc:id="fedcba98-7654-3210-fedc-ba9876543210" doc:name="Create Response">

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -180,28 +180,14 @@
 				}]]]]>
       </salesforce:records>
     </salesforce:create>
-    <choice doc:id="ee82b0c8-2c09-4456-a531a-80fba2c1e448" doc:name="Task creation successful?">
-      <when expression="#[payload.items[0].successful == false]">
-        <ee:transform doc:id="aab7a4b8-dfff-46734-bf3e-acdbb63ea782" doc:name="Create Error Response">
-          <ee:message>
-            <ee:set-payload>
-              <![CDATA[%dw 2.0
-						output application/json
-						---
-						{
-							message: payload.items[0].message
-						}]]>
-            </ee:set-payload>
-          </ee:message>
-          <ee:variables>
-            <ee:set-variable variableName="httpStatus">
-              <![CDATA[400]]>
-            </ee:set-variable>
-          </ee:variables>
-        </ee:transform>
-      </when>
-      <otherwise>
-        <ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+    <choice doc:name="Upsert successful?" doc:id="68b13fc9-8041-489c-8be5-85c45b554caf">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_TASK_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="f249a0dc-5aa0-4602-8892-7d3f88d9803e" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="981e406e-d3b3-40ef-a6eb-ed275aefe119" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="140608b5-54cf-46b4-bb71-72fc3936666b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+			</when>
+		</choice>
+    <ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
           <ee:message>
             <ee:set-payload>
               <![CDATA[%dw 2.0
@@ -213,9 +199,7 @@
             </ee:set-payload>
           </ee:message>
         </ee:transform>
-      </otherwise>
-    </choice>
-    <logger doc:id="640a58eb-a8ab-40f9-bcc23-a9cadcf86bb5" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
+		<logger doc:id="640a58eb-a8ab-40f9-bcc23-a9cadcf86bb5" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
   </flow>
   <flow name="patch:\tasks\(taskId):application\json:salesforce-data-api-config">
     <set-variable doc:id="e1f7ebc1-0e1e-45b9-88b6-d6c5c998b79c" doc:name="Set Task ID" value="#[attributes.uriParams.taskId]" variableName="taskId"></set-variable>
@@ -251,28 +235,15 @@
 				}]]]]>
       </salesforce:records>
     </salesforce:update>
-    <choice doc:id="abcdef12-3456-7890-abcd-ef1234567890" doc:name="Update Successful?">
-      <when expression="#[payload.items[0].successful == false]">
-        <ee:transform doc:id="abcd1234-5678-90ef-ghij-567890abcdef" doc:name="Create Error Response">
-          <ee:message>
-            <ee:set-payload>
-              <![CDATA[%dw 2.0
-						output application/json
-						---
-						{
-							message: payload.items[0].message
-						}]]>
-            </ee:set-payload>
-          </ee:message>
-          <ee:variables>
-            <ee:set-variable variableName="httpStatus">
-              <![CDATA[400]]>
-            </ee:set-variable>
-          </ee:variables>
-        </ee:transform>
-      </when>
-      <otherwise>
-        <ee:transform doc:id="fedcba98-7654-3210-fedc-ba9876543210" doc:name="Create Response">
+    <!-- Log Updated Response -->
+    <choice doc:name="Update successful?" doc:id="144c3f86-70f6-4c27-a17c-f66e53b9c09a">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_TASK_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="ccedeaca-059e-42c7-a1f1-7e366f3491a8" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="2a56b6a0-da4b-42be-8724-c1d6755eed24" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="72edbd97-752e-404a-a756-3b0f5fa9d27b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+			</when>
+		</choice>
+		<ee:transform doc:id="fedcba98-7654-3210-fedc-ba9876543210" doc:name="Create Response">
           <ee:message>
             <ee:set-payload>
               <![CDATA[%dw 2.0
@@ -285,18 +256,14 @@
             </ee:set-payload>
           </ee:message>
         </ee:transform>
-      </otherwise>
-    </choice>
-    <!-- Log Updated Response -->
-    <logger doc:id="log12345-67890-abcdef-ghijk" doc:name="Log Update Response" level="INFO" message="#[payload]"></logger>
+		<logger doc:id="log12345-67890-abcdef-ghijk" doc:name="Log Update Response" level="INFO" message="#[payload]"></logger>
     <!-- Exit Flow -->
   </flow>
   <flow name="delete:\tasks\(taskId):salesforce-data-api-config">
       <logger level="INFO" message="delete:\tasks\(taskId):salesforce-data-api-config"></logger>
 	  <set-variable variableName="taskId" value="#[attributes.uriParams.taskId]" doc:name="Set Task ID"></set-variable>
 	  <salesforce:query config-ref="Salesforce_Config" doc:id="1d085a1a-e15b-412b-a836-3014557a9abd" doc:name="Query to get tasks by contactId">
-      <salesforce:salesforce-query>
-        <![CDATA[
+      <salesforce:salesforce-query><![CDATA[
 				SELECT 
 					Id,
 					Assigned_By__c,
@@ -321,13 +288,11 @@
 					Id = ':taskId'
 			]]>
       </salesforce:salesforce-query>
-      <salesforce:parameters>
-        <![CDATA[#[output application/java
+      <salesforce:parameters><![CDATA[#[output application/java
 				---
 				{
 					taskId: vars.taskId,
-				}
-			]]]>
+				}]]]>
       </salesforce:parameters>
     </salesforce:query>
         <choice doc:name="Choice" doc:id="pjptpt" >

--- a/src/main/mule/teamseasons.xml
+++ b/src/main/mule/teamseasons.xml
@@ -144,7 +144,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ENROLLMENT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="228e9700-a1a4-4746-bc33-551331da7d44" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="d36375c3-f397-4add-b0f3-0fca23cd0f52" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="579e74cf-ed44-48c6-b31f-03e9e4def9e6" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="579e74cf-ed44-48c6-b31f-03e9e4def9e6" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating an enrollment record." />
 			</when>
 		</choice>
 		<ee:transform doc:name="Create Response" doc:id="8790764d-7b54-4f5f-b7ee-c9b6b3bc11f0" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
@@ -435,7 +435,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_TEAMSEASON_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="026cd259-9726-425e-bb66-154541a22d73" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="0170e543-819b-4a25-8da1-6bcde2b9d375" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="b2683551-d1b1-4f78-ab99-b790a30616ff" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a teamseason record." />
+				<raise-error doc:name="Raise error" doc:id="b2683551-d1b1-4f78-ab99-b790a30616ff" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a TeamSeason record." />
 			</when>
 		</choice>
 		<ee:transform doc:id="72afa280-ab53-48ec-ada3-2965f6254973" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">

--- a/src/main/mule/teamseasons.xml
+++ b/src/main/mule/teamseasons.xml
@@ -140,26 +140,16 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			</ee:message>
 		</ee:transform>
 		<salesforce:update type="Enrollment__c" doc:name="Update" doc:id="67bd555b-2024-4d3b-8720-24dcb8688184" config-ref="Salesforce_Config" />
-		<choice doc:name="Update successful?" doc:id="b659fb79-98a3-4c48-bd2e-e8e8c10dece4" >
-			<when expression="#[payload.items[0].successful == false]" >
-				<ee:transform doc:name="Create Error Response" doc:id="fffa0ab0-96f4-4218-bfb0-7ec3093ed912" >
-					<ee:message >
-						<ee:set-payload ><![CDATA[%dw 2.0
-						output application/json
-						---
-						{
-							message: payload.items[0].message
-						}]]></ee:set-payload>
-					</ee:message>
-					<ee:variables >
-						<ee:set-variable variableName="httpStatus" ><![CDATA[400]]></ee:set-variable>
-					</ee:variables>
-				</ee:transform>
+		<choice doc:name="Update successful?" doc:id="522e3dfd-dde2-41ec-8374-94bf23b7c298">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_ENROLLMENT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="228e9700-a1a4-4746-bc33-551331da7d44" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="d36375c3-f397-4add-b0f3-0fca23cd0f52" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="579e74cf-ed44-48c6-b31f-03e9e4def9e6" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an attendance record." />
 			</when>
-			<otherwise >
-				<ee:transform doc:name="Create Response" doc:id="8790764d-7b54-4f5f-b7ee-c9b6b3bc11f0" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
-					<ee:message >
-						<ee:set-payload ><![CDATA[%dw 2.0
+		</choice>
+		<ee:transform doc:name="Create Response" doc:id="8790764d-7b54-4f5f-b7ee-c9b6b3bc11f0" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 					output application/json
 					---
 					{
@@ -167,8 +157,6 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 					}]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-			</otherwise>
-		</choice>
 	</flow>
 	<flow name="get:\teamSeasons\(teamSeasonId):salesforce-data-api-config">
     <flow-ref doc:id="03174916-e85d-4c3c-9357-eee984a14887" doc:name="message-for-not-implemented-endpoints" name="message-for-not-implemented-endpoints"></flow-ref>
@@ -443,28 +431,14 @@ output application/java
       </ee:message>
     </ee:transform>
     <salesforce:update config-ref="Salesforce_Config" doc:id="d17f7124-2383-4f56-8891-5b990940aff1" doc:name="Update" type="Team_Season__c"></salesforce:update>
-    <choice doc:id="79b6ffa5-5d2c-4347-a0f2-b8b06a6e1763" doc:name="Update successful?">
-      <when expression="#[payload.items[0].successful == false]">
-        <ee:transform doc:id="2fd09e2d-9361-42f4-9031-a7794997ee0e" doc:name="Create Error Response">
-          <ee:message>
-            <ee:set-payload>
-              <![CDATA[%dw 2.0
-output application/json
----
-{
-	message: payload.items[0].message
-}]]>
-            </ee:set-payload>
-          </ee:message>
-          <ee:variables>
-            <ee:set-variable variableName="httpStatus">
-              <![CDATA[400]]>
-            </ee:set-variable>
-          </ee:variables>
-        </ee:transform>
-      </when>
-      <otherwise>
-        <ee:transform doc:id="72afa280-ab53-48ec-ada3-2965f6254973" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+    <choice doc:name="Update successful?" doc:id="a879b59b-0a00-4ac3-9198-2fd160012717">
+			<when expression="#[payload.successful == false]">
+				<set-variable value="#['SALESFORCE_TEAMSEASON_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="026cd259-9726-425e-bb66-154541a22d73" variableName="errorCustomType" />
+				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="0170e543-819b-4a25-8da1-6bcde2b9d375" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="b2683551-d1b1-4f78-ab99-b790a30616ff" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a teamseason record." />
+			</when>
+		</choice>
+		<ee:transform doc:id="72afa280-ab53-48ec-ada3-2965f6254973" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
           <ee:message>
             <ee:set-payload>
               <![CDATA[%dw 2.0
@@ -476,9 +450,7 @@ output application/json
             </ee:set-payload>
           </ee:message>
         </ee:transform>
-      </otherwise>
-    </choice>
-    <logger doc:id="7929814c-bb94-4872-a86f-211a4874b58a" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
+		<logger doc:id="7929814c-bb94-4872-a86f-211a4874b58a" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
   </flow>
   <flow name="get:\teamSeasons\searchByTeamName:salesforce-data-api-config">
     <logger doc:id="5702e8bf-921c-4af0-2a9f0-9bc9091adf34" doc:name="Log entry-flow" level="INFO" message="Method and Request Path stored as vars: method=#[vars.method], request path=#[vars.requestPath]. queryparams=#[attributes.queryParams]"></logger>


### PR DESCRIPTION
This PR addresses recent changes in the global error handler by adding custom error throws for all `CREATE` and `UPDATE` operations across all flows.

Besides, an improved system of error classification is implemented:
1) `DUPLICATES_DETECTED` and `MALFORMED_ID` detected in all custom errors
2) `SALESFORCE:INVALID_INPUT` is classified as `BAD_REQUEST`

In addition to that, `Payload Attached: No payload attached.` message is appended to the Slack message when payload is not provided.
