### PR TITLE
Sandbox: Automated Attendance Creation

### DIFF
--- a/docs/Scores - Salesforce Data API.postman_collection.json
+++ b/docs/Scores - Salesforce Data API.postman_collection.json
@@ -2123,6 +2123,51 @@
 					"response": []
 				},
 				{
+					"name": "/tasks/{taskId}",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "client_id",
+								"value": "{{sandbox_client_id}}"
+							},
+							{
+								"key": "client_secret",
+								"value": "{{sandbox_client_secret}}"
+							},
+							{
+								"key": "Origin",
+								"value": "Postman",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url_s}}/tasks/a40cX000000S43tQAC",
+							"host": [
+								"{{base_url_s}}"
+							],
+							"path": [
+								"tasks",
+								"a40cX000000S43tQAC"
+							]
+						},
+						"description": "BODY/JSON:\n\n{  \n\"TeamSeasonName\": \"\",  \n\"TeamId\": \"\",  \n\"SeasonId\": \"\",  \n\"SchoolSite\": \"\",  \n\"Partnership\": \"\",  \n\"TotalNoOfPlayers\": 0,  \n\"TotalNoOfSessions\": 0,  \n\"SeasonStartDate\": \"\",  \n\"SeasonEndDate\": \"\",  \n\"CoachSoccer\": \"\",  \n\"CoachWriting\": \"\",  \n\"ProgramCoordinator\": \"\",  \n\"ProgramManager\": \"\"  \n}"
+					},
+					"response": []
+				},
+				{
 					"name": "/tasks",
 					"request": {
 						"method": "POST",

--- a/src/main/mule/attendances.xml
+++ b/src/main/mule/attendances.xml
@@ -62,4 +62,5 @@ payload.items.*payload]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
 	</flow>
+	<flow name="createAttendancesForSessionBasedOnTeamSeasonId" doc:id="d2f0a7a1-82d1-4a8a-813a-f159fb27bab6" />
 	</mule>

--- a/src/main/mule/attendances.xml
+++ b/src/main/mule/attendances.xml
@@ -62,5 +62,78 @@ payload.items.*payload]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
 	</flow>
-	<flow name="createAttendancesForSessionBasedOnTeamSeasonId" doc:id="d2f0a7a1-82d1-4a8a-813a-f159fb27bab6" />
+	<flow name="createAttendancesForSessionBasedOnTeamSeasonId" doc:id="d2f0a7a1-82d1-4a8a-813a-f159fb27bab6" doc:description="You need to provide `vars.sessionId` and `vars.teamSeasonId` to make this flow working.">
+		<salesforce:query doc:name="Select Query with TeamSeasonId and SessionDate from Enrollment object" doc:id="31397a86-3870-4697-92ae-f734c7d86be6" config-ref="Salesforce_Config" target="enrollmentResponse" >
+			<salesforce:salesforce-query ><![CDATA[
+				SELECT Contact__c
+				FROM Enrollment__c 
+				WHERE Team_Season__c = ':teamSeasonId' 
+				AND Start_Date__c <= :sessionDate
+				AND End_Date__c >= :sessionDate
+				GROUP BY Contact__c
+				]]></salesforce:salesforce-query>
+			<salesforce:parameters ><![CDATA[#[output application/java
+				---
+				{
+					teamSeasonId : vars.teamSeasonId,
+					sessionDate : vars.sessionDate
+				}]]]></salesforce:parameters>
+		</salesforce:query>
+		<choice doc:name="Choice" doc:id="86473c10-da93-4ecf-adca-280a0853a1fc" >
+			<when expression="#[sizeOf(vars.enrollmentResponse) &gt; 0]" >
+				<ee:transform doc:name="Prepare Upsert" doc:id="37d4e96a-7adf-4ebc-8de6-d8b8c1098ab5" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+vars.enrollmentResponse map ( payload01 , indexOfPayload01 ) -> {
+	Contact__c: payload01.Contact__c,
+	Session__c: vars.sessionId,
+	Attended__c: false,
+	ExternalId__c: payload01.Contact__c ++ '-' ++ vars.sessionId
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+				<salesforce:upsert objectType="Attendance__c" externalIdFieldName="ExternalId__c" doc:name="Upsert Attendance" doc:id="8d6075d3-7f89-4f0f-b73d-5c968b34dbcf" config-ref="Salesforce_Config" >
+					<salesforce:records ><![CDATA[#[%dw 2.0
+output application/java
+---
+payload]]]></salesforce:records>
+				</salesforce:upsert>
+				<choice doc:name="Update successful?" doc:id="ea900b69-0047-4bef-ac0f-15da9e01b99d" >
+					<when expression="#[payload.successful == false]" >
+						<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="8375d93a-a7f5-4e2d-a92a-53ba380b0323" variableName="errorCustomType" />
+						<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="a7e6ab49-248a-4c8b-9ddd-e0a24ab6c201" variableName="errorCustomMessage" />
+						<raise-error doc:name="Raise error" doc:id="b2875b59-8341-4d5e-b0b7-b4b0563d5c28" type="CUSTOM:CUSTOM_ERROR" description="Session is created, but something went wrong while creating related attendances." />
+					</when>
+					<otherwise >
+						<ee:transform doc:name="Create Response" doc:id="5bada35e-878c-4cb8-88eb-2d05f2db4a17" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
+							<ee:message >
+								<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+  SessionId: vars.sessionId,
+  Attendances: payload.items map ((item, itemIndex) -> item.payload)
+}]]></ee:set-payload>
+							</ee:message>
+						</ee:transform>
+					</otherwise>
+				</choice>
+			</when>
+			<otherwise >
+				<ee:transform doc:name="Create Response" doc:id="807a31fe-7d01-43b3-991b-e733db1f3ef8" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+  SessionId: vars.sessionId,
+  Attendances: []
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</otherwise>
+		</choice>
+	</flow>
 	</mule>

--- a/src/main/mule/attendances.xml
+++ b/src/main/mule/attendances.xml
@@ -79,11 +79,9 @@ payload.items.*payload]]></ee:set-payload>
 					sessionDate : vars.sessionDate
 				}]]]></salesforce:parameters>
 		</salesforce:query>
-		<choice doc:name="Choice" doc:id="86473c10-da93-4ecf-adca-280a0853a1fc" >
-			<when expression="#[sizeOf(vars.enrollmentResponse) &gt; 0]" >
-				<ee:transform doc:name="Prepare Upsert" doc:id="37d4e96a-7adf-4ebc-8de6-d8b8c1098ab5" >
-					<ee:message >
-						<ee:set-payload ><![CDATA[%dw 2.0
+		<ee:transform doc:name="Prepare Upsert" doc:id="37d4e96a-7adf-4ebc-8de6-d8b8c1098ab5">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
 ---
 vars.enrollmentResponse map ( payload01 , indexOfPayload01 ) -> {
@@ -94,6 +92,50 @@ vars.enrollmentResponse map ( payload01 , indexOfPayload01 ) -> {
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
+		<set-variable value="#[payload]" doc:name='Set "upsert"' doc:id="9cebf1b6-9abb-4e0a-a5fa-0f6d79241265" variableName="upsert" />
+		<salesforce:query doc:name="Query to retrieve existing attendance records" doc:id="d825c898-0dd2-42be-9aa3-f15c41f5ed96" config-ref="Salesforce_Config">
+					<salesforce:salesforce-query><![CDATA[
+			SELECT 
+				Id,
+				Contact__r.Name,
+				Contact__c,
+				Attended__c 
+			FROM 
+				Attendance__c 
+			WHERE 
+				Session__c = ':sessionId' 
+			AND Contact_Record_Type__c = 'SCORES Student']]></salesforce:salesforce-query>
+					<salesforce:parameters><![CDATA[#[output application/java
+				---
+				{
+						sessionId : vars.sessionId
+				}]]]></salesforce:parameters>
+				</salesforce:query>
+		<ee:transform doc:name="Prepare Retrieve" doc:id="52395af1-4af3-4c4e-a910-7cf0d02e7831">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+payload map ( payload01 , indexOfPayload01 ) -> {
+	AttendanceId: payload01.Id,
+	StudentName: payload01.Contact__r.Name,
+	Attended: payload01.Attended__c default false,
+	StudentId: payload01.Contact__c default ""
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+		<set-variable value="#[payload]" doc:name='Set "retrieve"' doc:id="0922b1bf-c176-4f5b-8d1c-8f9b52aa0920" variableName="retrieve" />
+		<ee:transform doc:name="Filter Items" doc:id="49acf3f1-f654-4a91-9aa1-cda2bebadd62" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+var exists = vars.retrieve map (item, index) -> item.StudentId
+---
+vars.upsert filter (item) -> not (exists contains item.Contact__c)]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+		<choice doc:name="Choice" doc:id="86473c10-da93-4ecf-adca-280a0853a1fc" >
+			<when expression="#[sizeOf(payload) &gt; 0]" >
 				<salesforce:upsert objectType="Attendance__c" externalIdFieldName="ExternalId__c" doc:name="Upsert Attendance" doc:id="8d6075d3-7f89-4f0f-b73d-5c968b34dbcf" config-ref="Salesforce_Config" >
 					<salesforce:records ><![CDATA[#[%dw 2.0
 output application/java
@@ -106,34 +148,40 @@ payload]]]></salesforce:records>
 						<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="a7e6ab49-248a-4c8b-9ddd-e0a24ab6c201" variableName="errorCustomMessage" />
 						<raise-error doc:name="Raise error" doc:id="b2875b59-8341-4d5e-b0b7-b4b0563d5c28" type="CUSTOM:CUSTOM_ERROR" description="Session is created, but something went wrong while creating related attendances." />
 					</when>
-					<otherwise >
-						<ee:transform doc:name="Create Response" doc:id="5bada35e-878c-4cb8-88eb-2d05f2db4a17" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
-							<ee:message >
-								<ee:set-payload ><![CDATA[%dw 2.0
-output application/json
+				</choice>
+			</when>
+		</choice>
+		<salesforce:query doc:name="Retrieve All Attendances" doc:id="cbcdb96a-6d9b-4ed7-b31a-a2b9b712e481" config-ref="Salesforce_Config">
+							<salesforce:salesforce-query><![CDATA[
+			SELECT 
+				Id,
+				Contact__r.Name,
+				Contact__c,
+				Attended__c 
+			FROM 
+				Attendance__c 
+			WHERE 
+				Session__c = ':sessionid' 
+			AND Contact_Record_Type__c = 'SCORES Student'
+			]]></salesforce:salesforce-query>
+							<salesforce:parameters><![CDATA[#[output application/java
 ---
 {
-  SessionId: vars.sessionId,
-  Attendances: payload.items map ((item, itemIndex) -> item.payload)
+	sessionid : vars.sessionId
+}]]]></salesforce:parameters>
+						</salesforce:query>
+		<ee:transform doc:name="Transform Message" doc:id="006ce91a-0d6c-48b5-91d8-cf3d8ec0d15a" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+							<ee:message>
+								<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+payload map ( payload01 , indexOfPayload01 ) -> {
+	AttendanceId: payload01.Id,
+	StudentName: payload01.Contact__r.Name,
+	Attended: payload01.Attended__c default false,
+	StudentId: payload01.Contact__c default ""
 }]]></ee:set-payload>
 							</ee:message>
 						</ee:transform>
-					</otherwise>
-				</choice>
-			</when>
-			<otherwise >
-				<ee:transform doc:name="Create Response" doc:id="807a31fe-7d01-43b3-991b-e733db1f3ef8" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
-					<ee:message >
-						<ee:set-payload ><![CDATA[%dw 2.0
-output application/json
----
-{
-  SessionId: vars.sessionId,
-  Attendances: []
-}]]></ee:set-payload>
-					</ee:message>
-				</ee:transform>
-			</otherwise>
-		</choice>
 	</flow>
 	</mule>

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -696,43 +696,32 @@ output application/json
 			doc:name="Log Stored URI Params"
 			doc:id="f5fb5455-22c7-4d1f-b316-fa26806f3f1b"
 			message="URI Param - coachId: #[vars.coachId], teamseasonId: #[vars.teamSeasonId], sessionId: #[vars.sessionId] - stored as vars" />
-		<salesforce:query
-			doc:name="Query"
-			doc:id="2c95dcd3-8d07-446c-883b-98f1ae79ed9c"
-			config-ref="Salesforce_Config">
+		<salesforce:query doc:name="Query to get SessionDate from sessionId" doc:id="1ba5db69-b60e-4902-aee9-aad169f60f32" config-ref="Salesforce_Config">
 			<salesforce:salesforce-query><![CDATA[
-			SELECT 
-				Id,
-				Contact__r.Name,
-				Contact__c,
-				Attended__c 
-			FROM 
-				Attendance__c 
-			WHERE 
-				Session__c = ':sessionid' 
-			AND Contact_Record_Type__c = 'SCORES Student'
+				SELECT 
+					Id,
+					Session_Date__c
+				FROM 
+					Session__c
+				WHERE 
+					id = ':sessionId' 
+				LIMIT 1
 			]]></salesforce:salesforce-query>
 			<salesforce:parameters><![CDATA[#[output application/java
----
-{
-	sessionid : vars.sessionId
-}]]]></salesforce:parameters>
+				---
+				{
+						sessionId : vars.sessionId
+				}]]]></salesforce:parameters>
 		</salesforce:query>
-		<ee:transform
-			xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd"
-			doc:id="cc0b30b2-4bb2-4b3c-bfa8-72626dc8dc02">
-			<ee:message>
-				<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-payload map ( payload01 , indexOfPayload01 ) -> {
-	AttendanceId: payload01.Id,
-	StudentName: payload01.Contact__r.Name,
-	Attended: payload01.Attended__c default false,
-	StudentId: payload01.Contact__c default ""
-}]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
+		<set-variable value="#[payload[0].Session_Date__c]" doc:name="Set sessionDate" doc:id="363e64d3-c8d5-421d-b28f-c04f9262b79d" variableName="sessionDate" />
+		<choice doc:name="Choice" doc:id="6d8e6d25-2088-410e-828e-51b13da45dd2" doc:description="TO_DELETE: Delete once all sessions have dates.">
+			<when expression="#[isEmpty(vars.sessionDate)]">
+				<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="52e68134-0915-494b-b10b-9d832344936f" variableName="errorCustomType" />
+				<set-variable value="The given session doesn’t have a date. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="151cdac2-c9a1-4387-95da-8ec9bee0e995" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="e64e98e4-8893-4b7b-be3b-f03f5d774cef" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+			</when>
+		</choice>
+		<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="d2c9a729-d4e7-454a-9891-0b02770a9749" name="createAttendancesForSessionBasedOnTeamSeasonId" />
 		<logger
 			level="INFO"
 			doc:name="Log Created Response"

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -273,7 +273,11 @@ output application/json
 				<ee:set-payload><![CDATA[%dw 2.0
 output application/json
 ---
-payload]]></ee:set-payload>
+{
+    "SessionId": vars.sessionId,
+    "Attendances": payload
+}
+]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
 	</flow>

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -252,6 +252,18 @@ output application/java
 		<choice doc:name="Choice" doc:id="636e0665-a408-4d9e-9339-8b0345da5589" >
 			<when expression="#[vars.createAttendances]">
 				<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="26220665-5702-4b5f-9199-6ed08d3c4191" name="createAttendancesForSessionBasedOnTeamSeasonId" />
+				<ee:transform doc:name="Create Response" doc:id="a4e94cf9-897d-425c-8a69-8fea59b8728b" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+			<ee:message>
+				<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+    "SessionId": vars.sessionId,
+    "Attendances": payload
+}
+]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
 			</when>
 			<otherwise >
 				<ee:transform doc:name="Create Response" doc:id="bb26a451-14f2-416c-9d61-2c9e0953227d" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
@@ -268,18 +280,6 @@ output application/json
 			</otherwise>
 		</choice>
 		<logger level="INFO" doc:name="Log Created Response" doc:id="640a58eb-a8ab-40f9-bcc2-a9cadcf86bb5" message="#[payload]" />
-		<ee:transform doc:name="Create Response" doc:id="a4e94cf9-897d-425c-8a69-8fea59b8728b" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
-			<ee:message>
-				<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-    "SessionId": vars.sessionId,
-    "Attendances": payload
-}
-]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
 	</flow>
 	<flow name="delete:\sessions\(sessionId):salesforce-data-api-config" doc:id="d97b31a5-0ea7-46d3-a346-cbca136228e3" >
 		<logger level="INFO" doc:name="Log entry-flow" doc:id="9ae3dcc8-74f5-4189-b3c1-bd9656a059ec" message="Method and Request Path stored as vars: method=#[vars.method], request path=#[vars.requestPath]. queryparams=#[attributes.queryParams]" />

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -249,98 +249,33 @@ output application/java
 			</when>
 		</choice>
 		<set-variable value="#[payload.items[0].id]" doc:name="Set SessionId" doc:id="1bb65f85-ccb1-44dd-a649-6037aca328c7" variableName="sessionId" />
-		<choice doc:name="Choice" doc:id="f3a5ffb3-7fe7-4b3d-842c-f9a33d815e97" >
+		<choice doc:name="Choice" doc:id="636e0665-a408-4d9e-9339-8b0345da5589" >
 			<when expression="#[vars.createAttendances]">
-				<salesforce:query doc:name="Select Query with TeamSeasonId and SessionDate from Enrollment object" doc:id="4885618a-3146-49d5-8577-ea7d7b952dfd" config-ref="Salesforce_Config" target="enrollmentResponse">
-			<salesforce:salesforce-query><![CDATA[
-				SELECT Contact__c
-				FROM Enrollment__c 
-				WHERE Team_Season__c = ':teamSeasonId' 
-				AND Start_Date__c <= :sessionDate
-				AND End_Date__c >= :sessionDate
-				GROUP BY Contact__c
-				]]></salesforce:salesforce-query>
-			<salesforce:parameters><![CDATA[#[output application/java
-				---
-				{
-					teamSeasonId : vars.teamSeasonId,
-					sessionDate : vars.sessionDate
-				}]]]></salesforce:parameters>
-		</salesforce:query>
-				<choice doc:name="Choice" doc:id="f8b015c6-811d-4767-b2d4-fbdc06f5cbe9">
-					<when expression="#[sizeOf(vars.enrollmentResponse) &gt; 0]">
-						<ee:transform doc:name="Prepare Upsert" doc:id="71f3c55e-4143-4e4c-b79f-8ba9edffa0af">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-vars.enrollmentResponse map ( payload01 , indexOfPayload01 ) -> {
-	Contact__c: payload01.Contact__c,
-	Session__c: vars.sessionId,
-	Attended__c: false,
-	ExternalId__c: payload01.Contact__c ++ '-' ++ vars.sessionId
-}]]></ee:set-payload>
-					</ee:message>
-				</ee:transform>
-						<salesforce:upsert objectType="Attendance__c" externalIdFieldName="ExternalId__c" doc:name="Upsert Attendance" doc:id="f1d1f788-a0cf-454a-9084-bcec15198cd7" config-ref="Salesforce_Config">
-				<salesforce:records><![CDATA[#[%dw 2.0
-output application/java
----
-payload]]]></salesforce:records>
-			</salesforce:upsert>
-						<choice doc:name="Update successful?" doc:id="61cd491c-b2d8-443b-9a6d-8d94f8a6430a">
-					<when expression="#[payload.successful == false]">
-						<set-variable value="#['SALESFORCE_ATTENDANCE_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="072cca5f-6026-438d-9191-c6a827d70cb4" variableName="errorCustomType" />
-						<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="089a7668-1b0b-475f-8a91-1c225fe1598a" variableName="errorCustomMessage" />
-						<raise-error doc:name="Raise error" doc:id="17098c84-335f-42b4-bcd5-d8d18ce4aba4" type="CUSTOM:CUSTOM_ERROR" description="Session is created, but something went wrong while creating related attendances." />
-					</when>
-					<otherwise>
-						<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="6779c4d0-a8dc-4e33-befa-a4b77df09562">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/json
----
-{
-  SessionId: vars.sessionId,
-  Attendances: payload
-}]]></ee:set-payload>
-					</ee:message>
-				</ee:transform>
-					</otherwise>
-				</choice>
-					</when>
-					<otherwise >
-						<ee:transform doc:name="Create Response" doc:id="ddd986f8-234f-45dc-a10a-15b74b2736c4" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
-							<ee:message >
-								<ee:set-payload ><![CDATA[%dw 2.0
-output application/json
----
-{
-  SessionId: vars.sessionId,
-}]]></ee:set-payload>
-							</ee:message>
-						</ee:transform>
-					</otherwise>
-				</choice>
+				<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="26220665-5702-4b5f-9199-6ed08d3c4191" name="createAttendancesForSessionBasedOnTeamSeasonId" />
 			</when>
 			<otherwise >
-				<ee:transform doc:name="Create Response" doc:id="1f8861ce-ac3c-49ea-b90f-6e0c661f2e20" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
+				<ee:transform doc:name="Create Response" doc:id="bb26a451-14f2-416c-9d61-2c9e0953227d" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
 					<ee:message >
 						<ee:set-payload ><![CDATA[%dw 2.0
 output application/json
 ---
 {
-  SessionId: vars.sessionId,
+    "SessionId": vars.sessionId,
+    "Attendances": []
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</otherwise>
 		</choice>
-		<logger
-			level="INFO"
-			doc:name="Log Created Response"
-			doc:id="640a58eb-a8ab-40f9-bcc2-a9cadcf86bb5"
-			message="#[payload]" />
+		<logger level="INFO" doc:name="Log Created Response" doc:id="640a58eb-a8ab-40f9-bcc2-a9cadcf86bb5" message="#[payload]" />
+		<ee:transform doc:name="Create Response" doc:id="a4e94cf9-897d-425c-8a69-8fea59b8728b" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+			<ee:message>
+				<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+payload]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
 	</flow>
 	<flow name="delete:\sessions\(sessionId):salesforce-data-api-config" doc:id="d97b31a5-0ea7-46d3-a346-cbca136228e3" >
 		<logger level="INFO" doc:name="Log entry-flow" doc:id="9ae3dcc8-74f5-4189-b3c1-bd9656a059ec" message="Method and Request Path stored as vars: method=#[vars.method], request path=#[vars.requestPath]. queryparams=#[attributes.queryParams]" />

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -27,8 +27,7 @@
       </ee:variables>
     </ee:transform>
     <salesforce:query config-ref="Salesforce_Config" doc:id="1d085a1a-e15b-412b-a836-1014557a9abd" doc:name="Query to get tasks by contactId">
-      <salesforce:salesforce-query>
-        <![CDATA[
+      <salesforce:salesforce-query><![CDATA[
 				SELECT 
 					Id,
 					Assigned_By__c,
@@ -53,13 +52,11 @@
 					:query
 			]]>
       </salesforce:salesforce-query>
-      <salesforce:parameters>
-        <![CDATA[#[output application/java
+      <salesforce:parameters><![CDATA[#[output application/java
 				---
 				{
 					query: vars.query,
-				}
-			]]]>
+				}]]]>
       </salesforce:parameters>
     </salesforce:query>
     <ee:transform doc:id="cca12834-e1ee-4339-90ef-91c9be555af9" doc:name="Transform Message">
@@ -159,7 +156,44 @@
         </ee:set-variable>
       </ee:variables>
     </ee:transform>
-    <salesforce:create config-ref="Salesforce_Config" doc:id="dd33ee35c-1b02-4cc9-a47b-733ddccb4800" doc:name="Create" type="SCORES_Task__c">
+		<choice doc:name="Data check &amp; pre-load" doc:id="44870db5-ba71-49e7-a9d5-6872bd7160bc" doc:description='When session is empty, but task type is "Take Attendance", we throw an error.'>
+			<when expression='#[isEmpty(vars.originalPayload.Session) and vars.originalPayload.TaskType == "Take Attendance"]'>
+				<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="3046647c-9c65-4558-a74d-b6078713e542" variableName="errorCustomType" />
+				<set-variable value='The "Take Attendance" task is required to have a "Session".' doc:name="Set Custom Error Message" doc:id="1bd8ec9a-e801-487c-bbdb-f0a4264f4983" variableName="errorCustomMessage" />
+				<raise-error doc:name="Raise error" doc:id="e6795de9-af7c-4319-af47-636d2a40a4d1" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+			</when>
+				<when expression='#[vars.originalPayload.TaskType == "Take Attendance"]'>
+				<set-variable value="#[vars.originalPayload.Session]" doc:name="Set sessionId" doc:id="e427cb8b-01d6-4f14-be2c-5bec7aab7bb1" variableName="sessionId" />
+				<salesforce:query doc:name="Query to get teamSeadonId from sessionId" doc:id="dbdf786d-1b72-46a4-a36f-3b7e232f02a5" config-ref="Salesforce_Config" >
+					<salesforce:salesforce-query ><![CDATA[
+				SELECT 
+					Id,
+					Session_Date__c,
+					Team_Season__c
+				FROM 
+					Session__c
+				WHERE 
+					id = ':sessionId' 
+				LIMIT 1
+			]]></salesforce:salesforce-query>
+					<salesforce:parameters ><![CDATA[#[output application/java
+				---
+				{
+						sessionId : vars.sessionId
+				}]]]></salesforce:parameters>
+				</salesforce:query>
+				<set-variable value="#[payload[0].Team_Season__c]" doc:name="Set teamSeasonId" doc:id="d3307533-fec0-49d0-b3f3-c7b32c66e7b2" variableName="teamSeasonId" />
+				<set-variable value="#[payload[0].Session_Date__c]" doc:name="Set sessionDate" doc:id="a1e322bc-20af-48f4-9433-7ab679c0d374" variableName="sessionDate" />
+				<choice doc:name="Choice" doc:id="14436a51-5822-47c3-a672-ff566d203342" doc:description="TO_DELETE: Delete once all sessions have dates.">
+					<when expression="#[isEmpty(vars.sessionDate)]">
+						<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="64f6bf38-d982-450a-8071-903dcbff612f" variableName="errorCustomType" />
+						<set-variable value='The given session doesn’t have a date. Cannot proceed with creating a task and attendance records.' doc:name="Set Custom Error Message" doc:id="fa1c9ac2-ce7e-4f04-b051-664b0d3ec8f2" variableName="errorCustomMessage" />
+						<raise-error doc:name="Raise error" doc:id="a7f01881-a713-4c3c-824d-5094d17fe4eb" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+					</when>
+				</choice>
+			</when>
+		</choice>
+		<salesforce:create config-ref="Salesforce_Config" doc:id="dd33ee35c-1b02-4cc9-a47b-733ddccb4800" doc:name="Create" type="SCORES_Task__c">
       <salesforce:records>
         <![CDATA[#[output application/java
 				---
@@ -187,15 +221,21 @@
 				<raise-error doc:name="Raise error" doc:id="140608b5-54cf-46b4-bb71-72fc3936666b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
 			</when>
 		</choice>
-    <ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+		<set-variable value="#[payload.items[0].id]" doc:name="Set taskId" doc:id="9d95ea48-739e-446d-935c-de8565d88720" variableName="taskId" />
+		<choice doc:name="Choice" doc:id="b87648ee-0f55-4f8d-9a4c-444c5583432f" >
+			<when expression='#[vars.originalPayload.TaskType == "Take Attendance"]'>
+				<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="80deb6ec-4e06-4b64-8d20-44291f8784b9" name="createAttendancesForSessionBasedOnTeamSeasonId" />
+			</when>
+		</choice>
+		<ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
           <ee:message>
-            <ee:set-payload>
-              <![CDATA[%dw 2.0
-								output application/json
-								---
-								{
-								TaskId: payload.items[0].id
-								}]]>
+            <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+	TaskId: vars.taskId,
+	Attendances: payload.Attendances default []
+}]]>
             </ee:set-payload>
           </ee:message>
         </ee:transform>

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -88,7 +88,119 @@
       </ee:message>
     </ee:transform>
   </flow>
-  <flow name="get:\tasks\(taskId)\tags:salesforce-data-api-config">
+  <flow name="get:\tasks\(taskId):salesforce-data-api-config" doc:id="ee845f40-8d5f-450d-9ff4-dbf60c921d59" >
+		<logger level="INFO" doc:name="Logger" doc:id="1ade37fb-3af9-4776-97b0-14e7c3d5b619" message="get:\tasks:salesforce-data-api-config" />
+		<set-variable value="#[attributes.uriParams.'taskId']" doc:name="Set taskId" doc:id="2bd2507a-0698-4868-b0cd-51593e14fe2a" variableName="taskId"/>
+		<salesforce:query doc:name="Retrieve task by ID" doc:id="7c493213-e573-4102-83cb-db950a9f5a2c" config-ref="Salesforce_Config" >
+			<salesforce:salesforce-query ><![CDATA[
+				SELECT 
+					Id,
+					Assigned_By__c,
+					Assigned_To__c,
+					CreatedById,
+					Created_By_Contact__c,
+					Description__c,
+					Due_Date__c,
+					LastModifiedById,
+					Last_Modified_By_Contact__c,
+					OwnerId,
+					Priority__c,
+					Priority_Icon__c,
+					Resource_Link__c,
+					Session__c,
+					Name,
+					Task_Status__c,
+					Task_Type__c
+				FROM 
+					SCORES_Task__c
+				WHERE 
+					Id = ':taskId'
+				LIMIT 1
+			]]></salesforce:salesforce-query>
+			<salesforce:parameters ><![CDATA[#[output application/java
+				---
+				{
+					taskId : vars.taskId,
+				}]]]></salesforce:parameters>
+		</salesforce:query>
+		<ee:transform doc:name="Transform Message" doc:id="e085a7fa-dde1-4050-87d5-3f7eacba69cf" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+payload map ( payload01 , indexOfpayload01 ) -> {
+	"Id": payload01.Id,
+	"AssignedBy": payload01.Assigned_By__c as String default "",
+	"AssignedTo": payload01.Assigned_To__c as String default "",
+	"CreatedBy": payload01.CreatedById as String default "",
+	"CreatedContact": payload01.Created_By_Contact__c as String default "",
+	"Description": payload01.Description__c as String default "",
+	"DueDate": payload01.Due_Date__c as String default "",
+	"LastModifiedBy": payload01.LastModifiedById as String default "",
+	"LastModifiedContact": payload01.Last_Modified_By_Contact__c as String default "",
+	"OwnerId": payload01.OwnerId as String default "",
+	"Priority": payload01.Priority__c as String default "",
+	"PriorityIcon": payload01.Priority_Icon__c as String default "",
+	"ResourceLink": payload01.Resource_Link__c as String default "",
+	"Session": payload01.Session__c as String default "",
+	"Name": payload01.Name as String default "",
+	"TaskStatus": payload01.Task_Status__c as String default "",
+	"TaskType": payload01.Task_Type__c as String default ""
+}]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<set-variable value="#[payload[0]]" doc:name="Set task" doc:id="48c84f65-33f8-4dd1-98b2-edebce736627" variableName="task"/>
+		<ee:transform doc:name="Create Response" doc:id="d8122893-51ba-46bc-a6b2-16753ee3426f" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+vars.task]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<choice doc:name="Do we retrieve attendances?" doc:id="c3f4c5d9-605f-443c-a94e-ec85c809b45c" doc:description='When session is empty, but task type is "Take Attendance", we throw an error.' >
+			<when expression='#[vars.task.TaskType == "Take Attendance"]' >
+				<set-variable value="#[vars.task.Session]" doc:name="Set sessionId" doc:id="ca8c94e6-3b56-4e41-b929-64629b707e03" variableName="sessionId" />
+				<salesforce:query doc:name="Query to get teamSeadonId from sessionId" doc:id="f073f661-d986-46dc-bc8f-6d62857c144d" config-ref="Salesforce_Config" >
+					<salesforce:salesforce-query ><![CDATA[
+				SELECT 
+					Id,
+					Session_Date__c,
+					Team_Season__c
+				FROM 
+					Session__c
+				WHERE 
+					id = ':sessionId' 
+				LIMIT 1
+			]]></salesforce:salesforce-query>
+					<salesforce:parameters ><![CDATA[#[output application/java
+				---
+				{
+						sessionId : vars.sessionId
+				}]]]></salesforce:parameters>
+				</salesforce:query>
+				<set-variable value="#[payload[0].Team_Season__c]" doc:name="Set teamSeasonId" doc:id="0ff98eeb-2149-43f1-9082-5fafeec98a75" variableName="teamSeasonId" />
+				<set-variable value="#[payload[0].Session_Date__c]" doc:name="Set sessionDate" doc:id="b3ba57a3-042e-4b78-a891-3a97d633b797" variableName="sessionDate" />
+				<choice doc:name="Choice" doc:id="0e2c3bfc-21c5-4acd-815e-c31e5f7e9d15" doc:description="TO_DELETE: Delete once all sessions have dates." >
+					<when expression="#[isEmpty(vars.sessionDate)]" >
+						<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="14384c39-deb4-4f66-b847-04b61e455036" variableName="errorCustomType" />
+						<set-variable value="The given session doesn’t have a date. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="d3132527-7cda-480d-b28d-3aa2fe12c502" variableName="errorCustomMessage" />
+						<raise-error doc:name="Raise error" doc:id="fe77e915-6316-4296-bf94-dfb8b47eb37b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+					</when>
+				</choice>
+				<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="698c33b1-167a-446d-9db8-beac679f1b71" name="createAttendancesForSessionBasedOnTeamSeasonId" />
+			</when>
+		</choice>
+		<ee:transform doc:name="Create Response" doc:id="e5549aed-9eb8-49c8-8b90-8fbeefd18c13" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+vars.task ++ { Attendances: payload.Attendances default [] }]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+	</flow>
+	<flow name="get:\tasks\(taskId)\tags:salesforce-data-api-config">
     <logger level="INFO" message="get:\tasks\(taskId)\tags:salesforce-data-api-config"></logger>
     <ee:transform doc:id="7e56aada-f163-47f0-8ffc-213f1acd09a8" doc:name="Store Query parameters">
       <ee:variables>
@@ -98,8 +210,7 @@
       </ee:variables>
     </ee:transform>
     <salesforce:query config-ref="Salesforce_Config" doc:id="1d085a1-e15b-412b-a836-10142557a9abd" doc:name="Search By ownerId (contactId)">
-      <salesforce:salesforce-query>
-        <![CDATA[
+      <salesforce:salesforce-query><![CDATA[
 				SELECT 
 					Id,
 					SCORES_Task__c,
@@ -115,13 +226,11 @@
 					SCORES_Task__c = ':taskId'
 			]]>
       </salesforce:salesforce-query>
-      <salesforce:parameters>
-        <![CDATA[#[output application/java
+      <salesforce:parameters><![CDATA[#[output application/java
 				---
 				{
 					taskId : vars.taskId,
-				}
-			]]]>
+				}]]]>
       </salesforce:parameters>
     </salesforce:query>
     <ee:transform doc:id="cca12834-e1ee-4c39-90ef-91c9be555af9" doc:name="Transform Message">

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -90,7 +90,11 @@
   </flow>
   <flow name="get:\tasks\(taskId):salesforce-data-api-config" doc:id="ee845f40-8d5f-450d-9ff4-dbf60c921d59" >
 		<logger level="INFO" doc:name="Logger" doc:id="1ade37fb-3af9-4776-97b0-14e7c3d5b619" message="get:\tasks:salesforce-data-api-config" />
-		<set-variable value="#[attributes.uriParams.'taskId']" doc:name="Set taskId" doc:id="2bd2507a-0698-4868-b0cd-51593e14fe2a" variableName="taskId"/>
+		<choice doc:name="Choice" doc:id="f3d4c2fe-c966-41ab-88b6-f7908a91af55" >
+			<when expression="#[isEmpty(vars.taskId)]">
+				<set-variable value="#[attributes.uriParams.'taskId']" doc:name="Set taskId" doc:id="2bd2507a-0698-4868-b0cd-51593e14fe2a" variableName="taskId" />
+			</when>
+		</choice>
 		<salesforce:query doc:name="Retrieve task by ID" doc:id="7c493213-e573-4102-83cb-db950a9f5a2c" config-ref="Salesforce_Config" >
 			<salesforce:salesforce-query ><![CDATA[
 				SELECT 
@@ -189,9 +193,7 @@ vars.task]]></ee:set-payload>
 					</when>
 				</choice>
 				<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="698c33b1-167a-446d-9db8-beac679f1b71" name="createAttendancesForSessionBasedOnTeamSeasonId" />
-			</when>
-		</choice>
-		<ee:transform doc:name="Create Response" doc:id="e5549aed-9eb8-49c8-8b90-8fbeefd18c13" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+				<ee:transform doc:name="Create Response" doc:id="e5549aed-9eb8-49c8-8b90-8fbeefd18c13" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -199,6 +201,18 @@ output application/json
 vars.task ++ { Attendances: payload default [] }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
+			</when>
+			<otherwise>
+				<ee:transform doc:name="Create Response" doc:id="58983b9f-7ecf-4cfa-bfef-e959c992fb60" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+vars.task ++ { Attendances: [] }]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</otherwise>
+		</choice>
 	</flow>
 	<flow name="get:\tasks\(taskId)\tags:salesforce-data-api-config">
     <logger level="INFO" message="get:\tasks\(taskId)\tags:salesforce-data-api-config"></logger>
@@ -334,9 +348,7 @@ vars.task ++ { Attendances: payload default [] }]]></ee:set-payload>
 		<choice doc:name="Choice" doc:id="b87648ee-0f55-4f8d-9a4c-444c5583432f" >
 			<when expression='#[vars.originalPayload.TaskType == "Take Attendance"]'>
 				<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="80deb6ec-4e06-4b64-8d20-44291f8784b9" name="createAttendancesForSessionBasedOnTeamSeasonId" />
-			</when>
-		</choice>
-		<ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+				<ee:transform doc:id="291c1936-dfea-4dd5-aaba-c320a5a5b4311" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
           <ee:message>
             <ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -348,6 +360,21 @@ output application/json
             </ee:set-payload>
           </ee:message>
         </ee:transform>
+			</when>
+			<otherwise >
+				<ee:transform doc:name="Create Response" doc:id="24a76fb6-3fee-42a2-b158-dc7e93f66bf1" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+	TaskId: vars.taskId,
+	Attendances: []
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</otherwise>
+		</choice>
 		<logger doc:id="640a58eb-a8ab-40f9-bcc23-a9cadcf86bb5" doc:name="Log Created Response" level="INFO" message="#[payload]"></logger>
   </flow>
   <flow name="patch:\tasks\(taskId):application\json:salesforce-data-api-config">
@@ -385,26 +412,31 @@ output application/json
       </salesforce:records>
     </salesforce:update>
     <!-- Log Updated Response -->
-    <choice doc:name="Update successful?" doc:id="144c3f86-70f6-4c27-a17c-f66e53b9c09a">
+		<choice doc:name="Update successful? Attendance creation needed?" doc:id="144c3f86-70f6-4c27-a17c-f66e53b9c09a">
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_TASK_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="ccedeaca-059e-42c7-a1f1-7e366f3491a8" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="2a56b6a0-da4b-42be-8724-c1d6755eed24" variableName="errorCustomMessage" />
 				<raise-error doc:name="Raise error" doc:id="72edbd97-752e-404a-a756-3b0f5fa9d27b" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating a task record." />
 			</when>
-		</choice>
-		<ee:transform doc:id="fedcba98-7654-3210-fedc-ba9876543210" doc:name="Create Response">
+			<when expression='#[vars.originalPayload.TaskType == "Take Attendance"]'>
+				<flow-ref doc:name="Flow Reference" doc:id="47a9d17a-8757-4a4b-a248-5aec5c4df102" name="get:\tasks\(taskId):salesforce-data-api-config"/>
+			</when>
+			<otherwise >
+				<ee:transform doc:id="fedcba98-7654-3210-fedc-ba9876543210" doc:name="Create Response">
           <ee:message>
-            <ee:set-payload>
-              <![CDATA[%dw 2.0
-						output application/json
-						---
-						{
-							message: "Task updated successfully",
-							TaskId: vars.taskId
-						}]]>
+            <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+	message: "Task updated successfully",
+	TaskId: vars.taskId,
+	Attendances: []
+}]]>
             </ee:set-payload>
           </ee:message>
         </ee:transform>
+			</otherwise>
+		</choice>
 		<logger doc:id="log12345-67890-abcdef-ghijk" doc:name="Log Update Response" level="INFO" message="#[payload]"></logger>
     <!-- Exit Flow -->
   </flow>

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -196,7 +196,7 @@ vars.task]]></ee:set-payload>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
 ---
-vars.task ++ { Attendances: payload.Attendances default [] }]]></ee:set-payload>
+vars.task ++ { Attendances: payload default [] }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 	</flow>
@@ -343,7 +343,7 @@ output application/json
 ---
 {
 	TaskId: vars.taskId,
-	Attendances: payload.Attendances default []
+	Attendances: payload default []
 }]]>
             </ee:set-payload>
           </ee:message>

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -420,6 +420,18 @@ output application/json
 			</when>
 			<when expression='#[vars.originalPayload.TaskType == "Take Attendance"]'>
 				<flow-ref doc:name="Flow Reference" doc:id="47a9d17a-8757-4a4b-a248-5aec5c4df102" name="get:\tasks\(taskId):salesforce-data-api-config"/>
+				<ee:transform doc:name="Create Response" doc:id="1a3697e3-53dd-4fc1-ae29-4f4a9794a3ba" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+	message: "Task updated successfully",
+	TaskId: payload.Id,
+	Attendances: payload.Attendances
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
 			</when>
 			<otherwise >
 				<ee:transform doc:id="fedcba98-7654-3210-fedc-ba9876543210" doc:name="Create Response">

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -1231,6 +1231,36 @@ uses:
         description: The ID of the SCORES task to retrieve tags for
         type: string
         required: true
+    get: 
+      description: Retrieves a specific task by ID, including attendance records if available.
+      responses:
+        200:
+          body:
+            application/json:
+              type: types.SCORES_Task[]
+              example: |
+                [
+                  {
+                    "Id": "a01ABC123456789",
+                    "AssignedBy": "a012345678901234",
+                    "AssignedTo": "a098765432109876",
+                    "CreatedBy": "a056789012345678",
+                    "CreatedContact": "a034567890123456",
+                    "Description": "Task description here",
+                    "DueDate": "2024-11-30T00:00:00Z",
+                    "LastModifiedBy": "a078901234567890",
+                    "LastModifiedContact": "a098765432109876",
+                    "OwnerId": "a076543210987654",
+                    "Priority": 100.00,
+                    "PriorityIcon": "🔴",
+                    "ResourceLink": "https://example.com/resource",
+                    "Session": "a054321098765432",
+                    "Name": "Task Name",
+                    "TaskStatus": "Complete",
+                    "TaskType": "HR Requirement",
+                    "Attendances": []
+                  }
+                ]
     patch:
       description: Update a SCORES task
       body:


### PR DESCRIPTION
This PR brings a new endpoint `GET /tasks/{taskId}` and adds a flow to automatically create attendance records when the following events occur:

- `POST /tasks` (A task is created with the type `"Take Attendance"`)
- `PATCH /tasks/{taskId}` (An existing task is updated to have the type `"Take Attendance"`)
- `GET /tasks/{taskId}` (A task with the type `"Take Attendance"` is retrieved)
- `POST /sessions?createAttendances=True` (A session is created with the `createAttendances` flag explicitly set to `True`) 
- `GET /coach/{coachId}/teamseasons/{teamSeasonId}/sessions/{sessionId}/attendances` (Attendance records for a session are retrieved, triggering creation first)

Docummentation is accessible [here](https://github.com/AmericaSCORESBayArea/scoreslabs/blob/main/docs/auto-attendance-creation.md). 
Tests were conducted and documented [here](https://github.com/AmericaSCORESBayArea/scoreslabs/blob/main/qa/salesforce-data-api/auto-attendance-creation-test.md).