### PR TITLE
Sandbox: `DELETE /sessions/{sessionId}` improvements

### DIFF
--- a/docs/Scores - Salesforce Data API.postman_collection.json
+++ b/docs/Scores - Salesforce Data API.postman_collection.json
@@ -2188,7 +2188,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"AssignedBy\": \"\",\n    \"AssignedTo\": \"003cX000008IZnXQAW\",\n    \"CreatedByContact\": \"0051T000009eHfvQAE\",\n    \"CreatedContact\": \"\",\n    \"Description\": \"This is a test of the a task with a session ID\",\n    \"DueDate\": \"2024-11-30T00:00:00Z\",\n    \"LastModifiedBy\": \"0051T000009eHfvQAE\",\n    \"LastModifiedContact\": \"\",\n    \"OwnerId\": \"0051T000009eHfvQAE\",\n    \"Priority\": 76.2,\n    \"ResourceLink\": \"\",\n    \"Session\": \"a0pcX0000008y3pQAA\",\n    \"Name\": \"Third task to do!\",\n    \"TaskStatus\": \"Complete\",\n    \"TaskType\": \"HR Requirement\" \n}",
+							"raw": "{\n    \"AssignedBy\": \"\",\n    \"AssignedTo\": \"003cX000008IZnXQAW\",\n    \"CreatedByContact\": \"0051T000009eHfvQAE\",\n    \"CreatedContact\": \"\",\n    \"Description\": \"This is a test of the a task with a session ID\",\n    \"DueDate\": \"2024-11-30\",\n    \"LastModifiedBy\": \"0051T000009eHfvQAE\",\n    \"LastModifiedContact\": \"\",\n    \"OwnerId\": \"0051T000009eHfvQAE\",\n    \"Priority\": 76.2,\n    \"ResourceLink\": \"\",\n    \"Session\": \"a0pcX0000008y3pQAA\",\n    \"Name\": \"Third task to do!\",\n    \"TaskStatus\": \"Complete\",\n    \"TaskType\": \"HR Requirement\" \n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2229,7 +2229,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"AssignedBy\": \"\",\n    \"AssignedTo\": \"003cX000008IZnXQAW\",\n    \"CreatedByContact\": \"0051T000009eHfvQAE\",\n    \"CreatedContact\": \"\",\n    \"Description\": \"This is a test of the POST method #2.\",\n    \"DueDate\": \"2024-11-30T00:00:00Z\",\n    \"LastModifiedBy\": \"0051T000009eHfvQAE\",\n    \"LastModifiedContact\": \"\",\n    \"OwnerId\": \"0051T000009eHfvQAE\",\n    \"Priority\": 90.2,\n    \"ResourceLink\": \"\",\n    \"Session\": \"\",\n    \"Name\": \"Third task to do!!\",\n    \"TaskStatus\": \"Complete\",\n    \"TaskType\": \"HR Requirement\" \n}",
+							"raw": "{\n    \"AssignedBy\": \"\",\n    \"AssignedTo\": \"003cX000008IZnXQAW\",\n    \"CreatedByContact\": \"0051T000009eHfvQAE\",\n    \"CreatedContact\": \"\",\n    \"Description\": \"This is a test of the POST method #2.\",\n    \"DueDate\": \"2024-11-30\",\n    \"LastModifiedBy\": \"0051T000009eHfvQAE\",\n    \"LastModifiedContact\": \"\",\n    \"OwnerId\": \"0051T000009eHfvQAE\",\n    \"Priority\": 90.2,\n    \"ResourceLink\": \"\",\n    \"Session\": \"\",\n    \"Name\": \"Third task to do!!\",\n    \"TaskStatus\": \"Complete\",\n    \"TaskType\": \"HR Requirement\" \n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -721,7 +721,7 @@ output application/json
 		<choice doc:name="Choice" doc:id="6d8e6d25-2088-410e-828e-51b13da45dd2" doc:description="TO_DELETE: Delete once all sessions have dates.">
 			<when expression="#[isEmpty(vars.sessionDate)]">
 				<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="52e68134-0915-494b-b10b-9d832344936f" variableName="errorCustomType" />
-				<set-variable value="The given session doesn’t have a date. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="151cdac2-c9a1-4387-95da-8ec9bee0e995" variableName="errorCustomMessage" />
+				<set-variable value="The given session doesn’t have a date or does not exist. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="151cdac2-c9a1-4387-95da-8ec9bee0e995" variableName="errorCustomMessage" />
 				<raise-error doc:name="Raise error" doc:id="e64e98e4-8893-4b7b-be3b-f03f5d774cef" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
 			</when>
 		</choice>

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -289,38 +289,65 @@ output application/json
 				]]></ee:set-variable>
 			</ee:variables>
 		</ee:transform>
-		<salesforce:query doc:name="Select Query with sessionId from Assessment object" doc:id="1e288924-44bc-4e3c-b544-5b51936d7367" config-ref="Salesforce_Config" target="assesmentResponse" targetValue="#[output application/json &#10;---&#10;payload]">
-			<salesforce:salesforce-query ><![CDATA[SELECT Id FROM Assessment__c WHERE Session__c = ':sessionId'
+		<salesforce:query doc:name="Select Query with sessionId from Session object" doc:id="95a75432-c90d-4d93-8c18-fd4608b87383" config-ref="Salesforce_Config" target="sessionResponse" targetValue="#[output application/json &#10;---&#10;payload]">
+			<salesforce:salesforce-query><![CDATA[SELECT Id FROM Session__c WHERE Id = ':sessionId' LIMIT 1
 			]]></salesforce:salesforce-query>
-			<salesforce:parameters ><![CDATA[#[output application/java
+			<salesforce:parameters><![CDATA[#[output application/java
 ---
 {
 	sessionId : vars.sessionId
 }]]]></salesforce:parameters>
 		</salesforce:query>
-		<salesforce:query doc:name="Select Query with sessionId from Attendence object" doc:id="cfe08f1a-cc1a-4102-bf59-a6aaeb021ec5" config-ref="Salesforce_Config" target="attendanceResponse" targetValue="#[output application/json &#10;---&#10;payload]">
-			<salesforce:salesforce-query ><![CDATA[SELECT Id FROM Attendance__c WHERE  Session__c = ':sessionId' AND Attended__c = true
+		<choice doc:name="Choice" doc:id="fc9a823d-ec3d-43fa-9f0b-2a0b5c64f622" >
+			<when expression="isEmpty(vars.sessionResponse)">
+				<set-variable value="404" doc:name="Set Status Code" doc:id="11ceb518-30ca-42fd-be2d-719126a99750" variableName="httpStatus" />
+				<ee:transform doc:name="Session does not exist" doc:id="1011e495-7284-4c5b-a1fa-3164d3ace732" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+	"message" : "Session does not exist",
+	"assessmentIds": [],
+	"attendenceIds": [],
+	"success": false
+		
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<otherwise >
+				<salesforce:query doc:name="Select Query with sessionId from Assessment object" doc:id="1e288924-44bc-4e3c-b544-5b51936d7367" config-ref="Salesforce_Config" target="assesmentResponse" targetValue="#[output application/json &#10;---&#10;payload]">
+			<salesforce:salesforce-query><![CDATA[SELECT Id FROM Assessment__c WHERE Session__c = ':sessionId'
 			]]></salesforce:salesforce-query>
-			<salesforce:parameters ><![CDATA[#[output application/java
+			<salesforce:parameters><![CDATA[#[output application/java
 ---
 {
 	sessionId : vars.sessionId
 }]]]></salesforce:parameters>
 		</salesforce:query>
-		<set-variable value='#["true"]' doc:name="Set Variable" doc:id="6ed36b25-91dd-4429-bf78-2f5cb16190a2" variableName="sessionFlag"/>
-		<choice doc:name="Choice" doc:id="92f74e31-c84b-4d92-96a8-a54282a8f912" >
-			<when expression='#[isEmpty(vars.assesmentResponse) and isEmpty(vars.attendanceResponse)]'>
+				<salesforce:query doc:name="Select Query with sessionId from Attendence object" doc:id="cfe08f1a-cc1a-4102-bf59-a6aaeb021ec5" config-ref="Salesforce_Config" target="attendanceResponse" targetValue="#[output application/json &#10;---&#10;payload]">
+			<salesforce:salesforce-query><![CDATA[SELECT Id, Attended__c FROM Attendance__c WHERE  Session__c = ':sessionId'
+			]]></salesforce:salesforce-query>
+			<salesforce:parameters><![CDATA[#[output application/java
+---
+{
+	sessionId : vars.sessionId
+}]]]></salesforce:parameters>
+		</salesforce:query>
+				<set-variable value='#[%dw 2.0&#10;output application/json&#10;var attendedTrue = vars.attendanceResponse filter (item, itemIndex) -&gt; (item.Attended__c == "true")&#10;---&#10;{&#10;    toRemove: isEmpty(attendedTrue),&#10;    ids: vars.attendanceResponse map (item, itemIndex) -&gt; (item.Id),&#10;    idsTrue: attendedTrue map (item, itemIndex) -&gt; (item.Id)&#10;}]' doc:name="Set Attendances `toRemove` and `Ids`" doc:id="803dbfac-430e-491a-9576-ba7644ba9ccd" variableName="attendanceResponsePrepared"/>
+				<choice doc:name="Choice" doc:id="92f74e31-c84b-4d92-96a8-a54282a8f912">
+			<when expression="#[isEmpty(vars.assesmentResponse) and vars.attendanceResponsePrepared.toRemove]">
 				<ee:transform doc:name="sessionIds" doc:id="0fbc4a8b-63a7-4921-a442-cb27583294c7">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 ---
-[vars.sessionId]]]></ee:set-payload>
+vars.attendanceResponsePrepared.ids + vars.sessionId]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-				<salesforce:delete doc:name="Delete" doc:id="b57d6d95-dcd0-48de-a55e-f5bb0f1186d5" config-ref="Salesforce_Config" >
-				</salesforce:delete>
-				<ee:transform doc:name="Transform Message" doc:id="903290a7-d881-491c-801e-80979a824387">
+				<salesforce:delete doc:name="Delete" doc:id="6f2a821e-2e0f-416d-a109-983073873bba" config-ref="Salesforce_Config" />
+						<ee:transform doc:name="Transform Message" doc:id="903290a7-d881-491c-801e-80979a824387">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
@@ -328,52 +355,47 @@ output application/json
 payload]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
-				<choice doc:name="Choice" doc:id="100917c1-dab8-4514-a8f8-9f37f8ab0948">
-					<when expression="#[payload.successful == true]">
-						<ee:transform doc:name="success response" doc:id="6f9995d5-7f26-43e0-84b5-37947225a965" >
-							<ee:message >
-								<ee:set-payload ><![CDATA[%dw 2.0
+						<choice doc:name="Update successful?" doc:id="57cfc27f-d39b-489a-a941-195e88648fa2" >
+							<when expression="#[payload.successful == false]" >
+								<set-variable value="#['SALESFORCE_SESSION_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="599e729e-d7a1-4679-91a0-694cf584353c" variableName="errorCustomType" />
+								<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="cb64c6a4-6537-4a20-a9ad-fb2248e6bb68" variableName="errorCustomMessage" />
+								<raise-error doc:name="Raise error" doc:id="d432f898-eca8-410d-b79b-50cf1dffbd6f" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a session record." />
+							</when>
+							<otherwise >
+								<ee:transform doc:name="Success Response" doc:id="6f9995d5-7f26-43e0-84b5-37947225a965">
+							<ee:message>
+								<ee:set-payload><![CDATA[%dw 2.0
 output application/json
 ---
 {
-	"message" : "session is deleted successfully",
+	"message" : "Session and related attendances are deleted successfully",
 	"sessionId": vars.sessionId,
+	"attendenceIds": vars.attendanceResponsePrepared.ids,
 	"success": true
 }]]></ee:set-payload>
 							</ee:message>
 						</ee:transform>
-					</when>
-					<otherwise >
-						<ee:transform doc:name="Error response" doc:id="d4dc91ae-9b28-418d-9dfe-93075831d489" >
-							<ee:message >
-								<ee:set-payload ><![CDATA[%dw 2.0
-output application/json
----
-{
-	"message" : "Error while deleting session",
-	"sessionId": vars.sessionId,
-	"success": false
-}]]></ee:set-payload>
-							</ee:message>
-						</ee:transform>
-					</otherwise>
-				</choice>
+							</otherwise>
+						</choice>
 			</when>
-			<otherwise >
-				<ee:transform doc:name="Session is active" doc:id="cb95577e-30b3-42c4-9320-2d4238060952" >
-					<ee:message >
-						<ee:set-payload ><![CDATA[%dw 2.0
+			<otherwise>
+				<set-variable value="409" doc:name="Set Status Code" doc:id="160ffd55-710a-4baa-88f4-82c6f288f3ef" variableName="httpStatus" />
+						<ee:transform doc:name="Session is active" doc:id="cb95577e-30b3-42c4-9320-2d4238060952">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 output application/json
 ---
 {
-	"message" : "Session is active",
+	"message" : "There are students attended this session, therefore the session is active and cannot be removed",
 	"assessmentIds": vars.assesmentResponse,
-	"attendenceIds": vars.attendanceResponse,
+	"attendenceIds": vars.attendanceResponsePrepared.idsTrue,
 	"success": false
 		
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
+			</otherwise>
+		</choice>
 			</otherwise>
 		</choice>
 	</flow>

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -187,8 +187,8 @@ vars.task]]></ee:set-payload>
 				<set-variable value="#[payload[0].Session_Date__c]" doc:name="Set sessionDate" doc:id="b3ba57a3-042e-4b78-a891-3a97d633b797" variableName="sessionDate" />
 				<choice doc:name="Choice" doc:id="0e2c3bfc-21c5-4acd-815e-c31e5f7e9d15" doc:description="TO_DELETE: Delete once all sessions have dates." >
 					<when expression="#[isEmpty(vars.sessionDate)]" >
-						<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="14384c39-deb4-4f66-b847-04b61e455036" variableName="errorCustomType" />
-						<set-variable value="The given session doesn’t have a date. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="d3132527-7cda-480d-b28d-3aa2fe12c502" variableName="errorCustomMessage" />
+						<set-variable value="#['SALESFORCE_TASK_GET:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="14384c39-deb4-4f66-b847-04b61e455036" variableName="errorCustomType" />
+						<set-variable value="The given session doesn’t have a date or does not exist. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="d3132527-7cda-480d-b28d-3aa2fe12c502" variableName="errorCustomMessage" />
 						<raise-error doc:name="Raise error" doc:id="fe77e915-6316-4296-bf94-dfb8b47eb37b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
 					</when>
 				</choice>
@@ -310,7 +310,7 @@ vars.task ++ { Attendances: [] }]]></ee:set-payload>
 				<choice doc:name="Choice" doc:id="14436a51-5822-47c3-a672-ff566d203342" doc:description="TO_DELETE: Delete once all sessions have dates.">
 					<when expression="#[isEmpty(vars.sessionDate)]">
 						<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="64f6bf38-d982-450a-8071-903dcbff612f" variableName="errorCustomType" />
-						<set-variable value='The given session doesn’t have a date. Cannot proceed with creating a task and attendance records.' doc:name="Set Custom Error Message" doc:id="fa1c9ac2-ce7e-4f04-b051-664b0d3ec8f2" variableName="errorCustomMessage" />
+						<set-variable value='The given session doesn’t have a date or does not exist. Cannot proceed with creating a task and attendance records.' doc:name="Set Custom Error Message" doc:id="fa1c9ac2-ce7e-4f04-b051-664b0d3ec8f2" variableName="errorCustomMessage" />
 						<raise-error doc:name="Raise error" doc:id="a7f01881-a713-4c3c-824d-5094d17fe4eb" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
 					</when>
 				</choice>


### PR DESCRIPTION
Update the `DELETE /sessions/{sessionId}` endpoint so that it correctly deletes associated attendance records and prevents deletion of unrelated IDs. 

Link to documentation: https://github.com/AmericaSCORESBayArea/scoreslabs/blob/main/docs/session-delete.md
Link to tests: https://github.com/AmericaSCORESBayArea/scoreslabs/blob/main/qa/salesforce-data-api/delete-session.md