### PR TITLE
New Endpoints: `GET /enrollments/dropreasons` and `GET /tasks/{coachId}/stats`

### DIFF
--- a/.github/workflows/on-push-build-and-deploy.yml
+++ b/.github/workflows/on-push-build-and-deploy.yml
@@ -125,6 +125,8 @@ jobs:
           -Dslack.client_id="${{ secrets.SLACK_CLIENT_ID }}" \
           -Dslack.client_secret="${{ secrets.SLACK_CLIENT_SECRET }}" \
           -Dslack.enabled=true \
+          -DworkerType=MEDIUM \
+          -Dworkers=1 \
           -DskipTests
  
 

--- a/.github/workflows/production-on-push-build-and-deploy.yml
+++ b/.github/workflows/production-on-push-build-and-deploy.yml
@@ -125,6 +125,8 @@ jobs:
           -Dslack.client_id="${{ secrets.SLACK_CLIENT_ID }}" \
           -Dslack.client_secret="${{ secrets.SLACK_CLIENT_SECRET }}" \
           -Dslack.enabled=true \
+          -DworkerType=MEDIUM \
+          -Dworkers=1 \
           -DskipTests
  
 

--- a/mule-artifact.json
+++ b/mule-artifact.json
@@ -9,7 +9,7 @@
   ],
   "redeploymentEnabled": true,
   "name": "secure-properties",
-  "minMuleVersion": "4.6.14",
+  "minMuleVersion": "4.6.15",
   "requiredProduct": "MULE_EE",
   "classLoaderModelLoaderDescriptor": {
     "id": "mule",

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -722,7 +722,7 @@ output application/json
 			<when expression="#[isEmpty(vars.sessionDate)]">
 				<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="52e68134-0915-494b-b10b-9d832344936f" variableName="errorCustomType" />
 				<set-variable value="The given session doesn’t have a date or does not exist. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="151cdac2-c9a1-4387-95da-8ec9bee0e995" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="e64e98e4-8893-4b7b-be3b-f03f5d774cef" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+				<raise-error doc:name="Raise error" doc:id="e64e98e4-8893-4b7b-be3b-f03f5d774cef" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a task record." />
 			</when>
 		</choice>
 		<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="d2c9a729-d4e7-454a-9891-0b02770a9749" name="createAttendancesForSessionBasedOnTeamSeasonId" />
@@ -1250,7 +1250,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ATTENDANCE_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="de0127f1-9543-4247-98f0-4919cad5e132" variableName="errorCustomType" />
 				<set-variable value='#[%dw 2.0&#10;output text/plain&#10;---&#10;(payload.items[0].message default "Error While Updating Attendances.") ++ &#10;(&#10;  payload.items map ((payload01, indexOfPayload01) -&gt; &#10;    " Message: " ++ write(payload01.payload default "", "application/json")&#10;  ) joinBy ""&#10;)]' doc:name="Set Custom Error Message" doc:id="8d77c108-0e3c-4930-9f49-9734837df79c" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="a938155b-3242-4787-a33d-46ab6e9cdfaa" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating an attendance record." />
+				<raise-error doc:name="Raise error" doc:id="a938155b-3242-4787-a33d-46ab6e9cdfaa" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while updating an attendance record." />
 			</when>
 		</choice>
 		<ee:transform doc:name="Create Response" doc:id="fb3860fc-e16f-4661-ac7a-6df2a8cb4053" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
@@ -1311,7 +1311,7 @@ output application/json
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ASSESSMENT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="116d4fa4-38ec-4d54-aa7e-5a37736d91c3" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="69573011-d907-4da1-9113-f1eff05db828" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="2be38cb1-dd0f-47cc-be2f-6fa6cc505545" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating an assessment record." />
+				<raise-error doc:name="Raise error" doc:id="2be38cb1-dd0f-47cc-be2f-6fa6cc505545" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating an assessment record." />
 			</when>
 		</choice>
 		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="aa2451bf-0b3f-4de0-9be9-fd354e65d674">

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -474,7 +474,8 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				SystemModstamp,
 				Team_Season__c,
 				Dropped__c,
-				Drop_Reason__c
+				Drop_Reason__c,
+				Other_Drop_Reason_If_Selected__c
 			FROM 
 				Enrollment__c 
 			WHERE 
@@ -519,6 +520,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 	StudentRecordComplete: (payload01.Contact__r.Student_Record_Complete__c as String) as Boolean default false,
 	Dropped: payload01.Dropped__c as Boolean default false,
 	DropReason: payload01.Drop_Reason__c default "",
+	OtherDropReason: payload01.Other_Drop_Reason_If_Selected__c default "",
 	ParentInfo: {
 		FirstName: payload01.Contact__r.Parent_First_Name__c default "",
 		LastName: payload01.Contact__r.Parent_Last_Name__c default "",
@@ -721,7 +723,7 @@ output application/json
 		<choice doc:name="Choice" doc:id="6d8e6d25-2088-410e-828e-51b13da45dd2" doc:description="TO_DELETE: Delete once all sessions have dates.">
 			<when expression="#[isEmpty(vars.sessionDate)]">
 				<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="52e68134-0915-494b-b10b-9d832344936f" variableName="errorCustomType" />
-				<set-variable value="The given session doesn’t have a date or does not exist. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="151cdac2-c9a1-4387-95da-8ec9bee0e995" variableName="errorCustomMessage" />
+				<set-variable value="The given session doesn't have a date or does not exist. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="151cdac2-c9a1-4387-95da-8ec9bee0e995" variableName="errorCustomMessage" />
 				<raise-error doc:name="Raise error" doc:id="e64e98e4-8893-4b7b-be3b-f03f5d774cef" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a task record." />
 			</when>
 		</choice>

--- a/src/main/mule/contacts.xml
+++ b/src/main/mule/contacts.xml
@@ -1146,7 +1146,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_CONTACT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="7ad844ad-82d9-4148-9596-96f4a5f508b1" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="fd73d10f-89d1-4744-b11d-9c8e02b886d6" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="42cf2f5b-f5ef-4d5b-9ef5-6eae1595fb5e" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating a contact record." />
+				<raise-error doc:name="Raise error" doc:id="42cf2f5b-f5ef-4d5b-9ef5-6eae1595fb5e" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while updating a contact record." />
 			</when>
 		</choice>
 		<flow-ref name="get:\contacts\(contactId):salesforce-data-api-config"></flow-ref>
@@ -1474,13 +1474,13 @@ attributes.queryParams.'searchString' replace /[&|!(){}\[\]^"~*?:\\'+\-]/ with("
 				<set-variable value="SEARCH:BAD_REQUEST" doc:name="Set Custom Error Type" doc:id="93817aa7-88f2-480e-b17e-172c65934d04" variableName="errorCustomType" />
 				<set-variable value="`searchString` is empty or includes only special characters" doc:name="Set Custom Error Message" doc:id="2bd394d4-e6fc-4155-ae4b-f7de594c0286" variableName="errorCustomMessage" />
 				<set-variable value="400" doc:name="Set Status Code" doc:id="0c98deb5-8566-4366-832d-f7f2ca65ed3e" variableName="httpStatus" />
-				<raise-error doc:name="Raise error1" doc:id="5ddc84e5-66a7-4edb-a986-c4990d471b8e" type="CUSTOM:CUSTOM_ERROR" description="Something went while performing a search." />
+				<raise-error doc:name="Raise error1" doc:id="5ddc84e5-66a7-4edb-a986-c4990d471b8e" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while performing a search." />
 			</when>
 			<when expression="#[sizeOf(vars.searchString) == 1]">
 				<set-variable value="SEARCH:BAD_REQUEST" doc:name="Set Custom Error Type" doc:id="907c8a99-990b-43e2-a2a9-90a8d01f14b7" variableName="errorCustomType" />
 				<set-variable value="`searchString` must be more than 1 character after cleaning from special characters." doc:name="Set Custom Error Message" doc:id="0617dfe4-bb94-47de-993c-547978c7ef6e" variableName="errorCustomMessage" />
 				<set-variable value="422" doc:name="Set Status Code" doc:id="dd0a4f31-e1a3-49ed-ba19-dfdfba7d1fd2" variableName="httpStatus" />
-				<raise-error doc:name="Raise error1" doc:id="23438120-62a7-4e1c-8dfe-e517777ff937" type="CUSTOM:CUSTOM_ERROR" description="Something went while performing a search." />
+				<raise-error doc:name="Raise error1" doc:id="23438120-62a7-4e1c-8dfe-e517777ff937" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while performing a search." />
 			</when>
 		</choice>
 		<salesforce:search config-ref="Salesforce_Config" doc:id="count-query" doc:name="Get Total Count">

--- a/src/main/mule/enrollments.xml
+++ b/src/main/mule/enrollments.xml
@@ -283,7 +283,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ENROLLMENT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="b9040877-1f5b-4788-a786-b5384e68f239" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="7c6fec7f-dbc4-46a3-917a-183fd5bc796b" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="844ccc3d-6ada-4719-aa14-1fad90ea1000" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating an enrollment record." />
+				<raise-error doc:name="Raise error" doc:id="844ccc3d-6ada-4719-aa14-1fad90ea1000" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while updating an enrollment record." />
 			</when>
 		</choice>
 		<ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:name="Create Response" doc:id="5cd8fa6a-e3d1-44de-9625-aff048e5fc8f">

--- a/src/main/mule/enrollments.xml
+++ b/src/main/mule/enrollments.xml
@@ -45,7 +45,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 				Start_Date__c,
 				Team_Season__c,
 				Dropped__c,
-				Drop_Reason__c
+				Drop_Reason__c,
+				Other_Drop_Reason_If_Selected__c
 			FROM 
 				Enrollment__c 
 			WHERE 
@@ -83,7 +84,8 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 	ParentFirstName: payload01.Contact__r.Parent_First_Name__c default "",
 	ParentLastName: payload01.Contact__r.Parent_Last_Name__c default "",
 	Dropped: payload01.Dropped__c as Boolean default false,
-	DropReason: payload01.Drop_Reason__c default ""
+	DropReason: payload01.Drop_Reason__c default "",
+	OtherDropReason: payload01.Other_Drop_Reason_If_Selected__c default ""
 }]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
@@ -142,7 +144,8 @@ output application/json
 				Start_Date__c,
 				Team_Season__c,
 				Dropped__c,
-				Drop_Reason__c
+				Drop_Reason__c,
+				Other_Drop_Reason_If_Selected__c
 			FROM 
 				Enrollment__c 
 			WHERE 
@@ -178,7 +181,8 @@ output application/json
 						Ethnicity: payload01.Contact__r.Ethnicity__c default "",
 						ZipCode: payload01.Contact__r.Zip_First_Five_Digits__c default "",
 						Dropped: payload01.Dropped__c as Boolean default false,
-						DropReason: payload01.Drop_Reason__c default ""
+						DropReason: payload01.Drop_Reason__c default "",
+						OtherDropReason: payload01.Other_Drop_Reason_If_Selected__c default ""
 					}]]>
 				</ee:set-payload>
 			</ee:message>
@@ -211,7 +215,8 @@ output application/json
 								Ethnicity: payload01.Ethnicity default "",
 								ZipCode: payload01.ZipCode default "",
 								Dropped: payload01.Dropped as Boolean default false,
-								DropReason: payload01.DropReason default ""
+								DropReason: payload01.DropReason default "",
+								OtherDropReason: payload01.OtherDropReason default ""
 							}]]>
 						</ee:set-payload>
 					</ee:message>
@@ -270,7 +275,8 @@ output application/java
 	(End_Date__c: payload.EndDate as Date {format: 'yyyy-MM-dd'}) if payload.EndDate != null,
 	(Team_Season__c: payload.TeamSeasonId) if payload.TeamSeasonId != null,
 	(Dropped__c: payload.Dropped) if payload.Dropped != null,
-	(Drop_Reason__c: payload.DropReason) if payload.DropReason != null
+	(Drop_Reason__c: payload.DropReason) if payload.DropReason != null,
+	(Other_Drop_Reason_If_Selected__c: payload.OtherDropReason) if payload.OtherDropReason != null
 }]]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
@@ -322,7 +328,8 @@ output application/java
 	(Start_Date__c: payload.StartDate as Date {format: 'yyyy-MM-dd'}) if payload.StartDate != null,
 	(End_Date__c: payload.EndDate as Date {format: 'yyyy-MM-dd'}) if payload.EndDate != null,
 	(Dropped__c: payload.Dropped) if payload.Dropped != null,
-	(Drop_Reason__c: payload.DropReason) if payload.DropReason != null
+	(Drop_Reason__c: payload.DropReason) if payload.DropReason != null,
+	(Other_Drop_Reason_If_Selected__c: payload.OtherDropReason) if payload.OtherDropReason != null
 }]]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
@@ -330,7 +337,7 @@ output application/java
 			<salesforce:create type="Enrollment__c" doc:name="Create" doc:id="c3404357-77e8-49ee-80c6-499595b2b643" config-ref="Salesforce_Config" />
 			<choice doc:name="Enrollment creation successful?" doc:id="ee82b0c8-2c09-4456-a51a-80fba2c1e448">
 			<when expression="#[payload.items[0].successful == false]">
-				<set-variable value="#['SALESFORCE_ENROLLMENT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="d5c68077-bb4c-4245-b6c5-68396295759c" variableName="errorCustomType" />
+					<set-variable value="#['SALESFORCE_ENROLLMENT_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="d5c68077-bb4c-4245-b6c5-68396295759c" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="f52e5839-b9ee-4a28-8944-62b63c974bc6" variableName="errorCustomMessage" />
 				<raise-error doc:name="Raise error" doc:id="20ccb42b-2476-402d-a634-7c7ae8243959" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating an enrollment record. " />
 			</when>

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -289,7 +289,9 @@ output application/json
 				]]></ee:set-variable>
 			</ee:variables>
 		</ee:transform>
-		<salesforce:query doc:name="Select Query with sessionId from Session object" doc:id="95a75432-c90d-4d93-8c18-fd4608b87383" config-ref="Salesforce_Config" target="sessionResponse" targetValue="#[output application/json &#10;---&#10;payload]">
+		<salesforce:query doc:name="Select Query with sessionId from Session object" doc:id="95a75432-c90d-4d93-8c18-fd4608b87383" config-ref="Salesforce_Config" target="sessionResponse" targetValue="#[output application/json 
+---
+payload]">
 			<salesforce:salesforce-query><![CDATA[SELECT Id FROM Session__c WHERE Id = ':sessionId' LIMIT 1
 			]]></salesforce:salesforce-query>
 			<salesforce:parameters><![CDATA[#[output application/java
@@ -317,7 +319,9 @@ output application/json
 				</ee:transform>
 			</when>
 			<otherwise >
-				<salesforce:query doc:name="Select Query with sessionId from Assessment object" doc:id="1e288924-44bc-4e3c-b544-5b51936d7367" config-ref="Salesforce_Config" target="assesmentResponse" targetValue="#[output application/json &#10;---&#10;payload]">
+				<salesforce:query doc:name="Select Query with sessionId from Assessment object" doc:id="1e288924-44bc-4e3c-b544-5b51936d7367" config-ref="Salesforce_Config" target="assesmentResponse" targetValue="#[output application/json 
+---
+payload]">
 			<salesforce:salesforce-query><![CDATA[SELECT Id FROM Assessment__c WHERE Session__c = ':sessionId'
 			]]></salesforce:salesforce-query>
 			<salesforce:parameters><![CDATA[#[output application/java
@@ -326,7 +330,9 @@ output application/json
 	sessionId : vars.sessionId
 }]]]></salesforce:parameters>
 		</salesforce:query>
-				<salesforce:query doc:name="Select Query with sessionId from Attendence object" doc:id="cfe08f1a-cc1a-4102-bf59-a6aaeb021ec5" config-ref="Salesforce_Config" target="attendanceResponse" targetValue="#[output application/json &#10;---&#10;payload]">
+				<salesforce:query doc:name="Select Query with sessionId from Attendence object" doc:id="cfe08f1a-cc1a-4102-bf59-a6aaeb021ec5" config-ref="Salesforce_Config" target="attendanceResponse" targetValue="#[output application/json 
+---
+payload]">
 			<salesforce:salesforce-query><![CDATA[SELECT Id, Attended__c FROM Attendance__c WHERE  Session__c = ':sessionId'
 			]]></salesforce:salesforce-query>
 			<salesforce:parameters><![CDATA[#[output application/java
@@ -335,7 +341,15 @@ output application/json
 	sessionId : vars.sessionId
 }]]]></salesforce:parameters>
 		</salesforce:query>
-				<set-variable value='#[%dw 2.0&#10;output application/json&#10;var attendedTrue = vars.attendanceResponse filter (item, itemIndex) -&gt; (item.Attended__c == "true")&#10;---&#10;{&#10;    toRemove: isEmpty(attendedTrue),&#10;    ids: vars.attendanceResponse map (item, itemIndex) -&gt; (item.Id),&#10;    idsTrue: attendedTrue map (item, itemIndex) -&gt; (item.Id)&#10;}]' doc:name="Set Attendances `toRemove` and `Ids`" doc:id="803dbfac-430e-491a-9576-ba7644ba9ccd" variableName="attendanceResponsePrepared"/>
+				<set-variable value='#[%dw 2.0
+output application/json
+var attendedTrue = vars.attendanceResponse filter (item, itemIndex) -&gt; (item.Attended__c == "true")
+---
+{
+    toRemove: isEmpty(attendedTrue),
+    ids: vars.attendanceResponse map (item, itemIndex) -&gt; (item.Id),
+    idsTrue: attendedTrue map (item, itemIndex) -&gt; (item.Id)
+}]' doc:name="Set Attendances `toRemove` and `Ids`" doc:id="803dbfac-430e-491a-9576-ba7644ba9ccd" variableName="attendanceResponsePrepared"/>
 				<choice doc:name="Choice" doc:id="92f74e31-c84b-4d92-96a8-a54282a8f912">
 			<when expression="#[isEmpty(vars.assesmentResponse) and vars.attendanceResponsePrepared.toRemove]">
 				<ee:transform doc:name="sessionIds" doc:id="0fbc4a8b-63a7-4921-a442-cb27583294c7">

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -189,7 +189,7 @@ vars.task]]></ee:set-payload>
 					<when expression="#[isEmpty(vars.sessionDate)]" >
 						<set-variable value="#['SALESFORCE_TASK_GET:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="14384c39-deb4-4f66-b847-04b61e455036" variableName="errorCustomType" />
 						<set-variable value="The given session doesn’t have a date or does not exist. Cannot proceed with creating a task and attendance records." doc:name="Set Custom Error Message" doc:id="d3132527-7cda-480d-b28d-3aa2fe12c502" variableName="errorCustomMessage" />
-						<raise-error doc:name="Raise error" doc:id="fe77e915-6316-4296-bf94-dfb8b47eb37b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+						<raise-error doc:name="Raise error" doc:id="fe77e915-6316-4296-bf94-dfb8b47eb37b" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a task record." />
 					</when>
 				</choice>
 				<flow-ref doc:name="Call `createAttendancesForSessionBasedOnTeamSeasonId`" doc:id="698c33b1-167a-446d-9db8-beac679f1b71" name="createAttendancesForSessionBasedOnTeamSeasonId" />
@@ -283,7 +283,7 @@ vars.task ++ { Attendances: [] }]]></ee:set-payload>
 			<when expression='#[isEmpty(vars.originalPayload.Session) and vars.originalPayload.TaskType == "Take Attendance"]'>
 				<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="3046647c-9c65-4558-a74d-b6078713e542" variableName="errorCustomType" />
 				<set-variable value='The "Take Attendance" task is required to have a "Session".' doc:name="Set Custom Error Message" doc:id="1bd8ec9a-e801-487c-bbdb-f0a4264f4983" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="e6795de9-af7c-4319-af47-636d2a40a4d1" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+				<raise-error doc:name="Raise error" doc:id="e6795de9-af7c-4319-af47-636d2a40a4d1" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a task record." />
 			</when>
 				<when expression='#[vars.originalPayload.TaskType == "Take Attendance"]'>
 				<set-variable value="#[vars.originalPayload.Session]" doc:name="Set sessionId" doc:id="e427cb8b-01d6-4f14-be2c-5bec7aab7bb1" variableName="sessionId" />
@@ -311,7 +311,7 @@ vars.task ++ { Attendances: [] }]]></ee:set-payload>
 					<when expression="#[isEmpty(vars.sessionDate)]">
 						<set-variable value="#['SALESFORCE_TASK_CREATE:BAD_REQUEST']" doc:name="Set Custom Error Type" doc:id="64f6bf38-d982-450a-8071-903dcbff612f" variableName="errorCustomType" />
 						<set-variable value='The given session doesn’t have a date or does not exist. Cannot proceed with creating a task and attendance records.' doc:name="Set Custom Error Message" doc:id="fa1c9ac2-ce7e-4f04-b051-664b0d3ec8f2" variableName="errorCustomMessage" />
-						<raise-error doc:name="Raise error" doc:id="a7f01881-a713-4c3c-824d-5094d17fe4eb" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+						<raise-error doc:name="Raise error" doc:id="a7f01881-a713-4c3c-824d-5094d17fe4eb" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a task record." />
 					</when>
 				</choice>
 			</when>
@@ -341,7 +341,7 @@ vars.task ++ { Attendances: [] }]]></ee:set-payload>
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_TASK_CREATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="f249a0dc-5aa0-4602-8892-7d3f88d9803e" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="981e406e-d3b3-40ef-a6eb-ed275aefe119" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="140608b5-54cf-46b4-bb71-72fc3936666b" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a task record." />
+				<raise-error doc:name="Raise error" doc:id="140608b5-54cf-46b4-bb71-72fc3936666b" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a task record." />
 			</when>
 		</choice>
 		<set-variable value="#[payload.items[0].id]" doc:name="Set taskId" doc:id="9d95ea48-739e-446d-935c-de8565d88720" variableName="taskId" />
@@ -416,7 +416,7 @@ output application/json
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_TASK_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="ccedeaca-059e-42c7-a1f1-7e366f3491a8" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="2a56b6a0-da4b-42be-8724-c1d6755eed24" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="72edbd97-752e-404a-a756-3b0f5fa9d27b" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating a task record." />
+				<raise-error doc:name="Raise error" doc:id="72edbd97-752e-404a-a756-3b0f5fa9d27b" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while updating a task record." />
 			</when>
 			<when expression='#[vars.originalPayload.TaskType == "Take Attendance"]'>
 				<flow-ref doc:name="Flow Reference" doc:id="47a9d17a-8757-4a4b-a248-5aec5c4df102" name="get:\tasks\(taskId):salesforce-data-api-config"/>

--- a/src/main/mule/teamseasons.xml
+++ b/src/main/mule/teamseasons.xml
@@ -144,7 +144,7 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_ENROLLMENT_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="228e9700-a1a4-4746-bc33-551331da7d44" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="d36375c3-f397-4add-b0f3-0fca23cd0f52" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="579e74cf-ed44-48c6-b31f-03e9e4def9e6" type="CUSTOM:CUSTOM_ERROR" description="Something went while updating an enrollment record." />
+				<raise-error doc:name="Raise error" doc:id="579e74cf-ed44-48c6-b31f-03e9e4def9e6" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while updating an enrollment record." />
 			</when>
 		</choice>
 		<ee:transform doc:name="Create Response" doc:id="8790764d-7b54-4f5f-b7ee-c9b6b3bc11f0" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
@@ -435,7 +435,7 @@ output application/java
 			<when expression="#[payload.successful == false]">
 				<set-variable value="#['SALESFORCE_TEAMSEASON_UPDATE:' ++ (payload.items[0].statusCode default 'UNKNOWN')]" doc:name="Set Custom Error Type" doc:id="026cd259-9726-425e-bb66-154541a22d73" variableName="errorCustomType" />
 				<set-variable value="#[payload.items[0].message default 'Unknown Error']" doc:name="Set Custom Error Message" doc:id="0170e543-819b-4a25-8da1-6bcde2b9d375" variableName="errorCustomMessage" />
-				<raise-error doc:name="Raise error" doc:id="b2683551-d1b1-4f78-ab99-b790a30616ff" type="CUSTOM:CUSTOM_ERROR" description="Something went while creating a TeamSeason record." />
+				<raise-error doc:name="Raise error" doc:id="b2683551-d1b1-4f78-ab99-b790a30616ff" type="CUSTOM:CUSTOM_ERROR" description="Something went wrong while creating a TeamSeason record." />
 			</when>
 		</choice>
 		<ee:transform doc:id="72afa280-ab53-48ec-ada3-2965f6254973" doc:name="Create Response" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">

--- a/src/main/resources/api/datatypes.raml
+++ b/src/main/resources/api/datatypes.raml
@@ -359,6 +359,9 @@ types:
         type: boolean
       DropReason:
         type: string
+      OtherDropReason:
+        type: string
+        required: false
     examples: !include enrollment-examples.raml
 
   EnrollmentByContactID:
@@ -396,6 +399,9 @@ types:
       DropReason:
         type: string
         required: false
+      OtherDropReason:
+        type: string
+        required: false
 
   EnrollmentUpdateModel:
     type: object
@@ -417,6 +423,9 @@ types:
         type: boolean
         required: false
       DropReason:
+        type: string
+        required: false
+      OtherDropReason:
         type: string
         required: false
   EnrollmentUpdateModelDatesOnly:

--- a/src/main/resources/api/enrollment-examples.raml
+++ b/src/main/resources/api/enrollment-examples.raml
@@ -17,5 +17,6 @@ enrollment-examples:
     "ZipCode": "94601",
     "Date": "2019-08-23",
     "Dropped": false,
-    "DropReason": ""
+    "DropReason": "",
+    "OtherDropReason": ""
   }

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -1247,7 +1247,7 @@ uses:
                     "CreatedBy": "a056789012345678",
                     "CreatedContact": "a034567890123456",
                     "Description": "Task description here",
-                    "DueDate": "2024-11-30T00:00:00Z",
+                    "DueDate": "2024-11-30",
                     "LastModifiedBy": "a078901234567890",
                     "LastModifiedContact": "a098765432109876",
                     "OwnerId": "a076543210987654",


### PR DESCRIPTION
**This PR fixes a few typos in error messages, adds "Other_Drop_Reason_If_Selected__c" field as "OtherDropReason" and introduces two new endpoints:**

- **1. `GET /enrollments/dropreasons`**  
Retrieves the picklist values for the `Drop_Reason__c` field from the `Enrollment__c` object and returns them in the following format:

```json
  [
    "Schedule Conflict",
    "Moved Away",
    "Lost Interest",
    "Health Reasons",
    "Disciplinary Action",
    "Other"
  ]
```

- **2. `GET /tasks/{coachId}/stats`**  
Retrieves basic stats for a coach based on the `Assigned_To__c` field and returns the results in the following format:

```json
  {
    "Not Started": 1,
    "Started": 0,
    "Complete": 41
  }
```