### PR TITLE
Enhancements: Add 'X-Firebase-UID' Header, New Endpoints for Coach Team Seasons Stats, Date Filter for Sessions, and Task Creation Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ src/main/resources/deploy.json
 src/main/resources/keystore.jks
 /bin/
 /venv
+/docs/data

--- a/docs/Scores - Salesforce Data API.postman_collection.json
+++ b/docs/Scores - Salesforce Data API.postman_collection.json
@@ -2008,6 +2008,40 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "/coach/{coachId}/stats",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "client_id",
+								"value": "{{sandbox_client_id}}"
+							},
+							{
+								"key": "client_secret",
+								"value": "{{sandbox_client_secret}}"
+							},
+							{
+								"key": "Origin",
+								"value": "Postman",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{base_url_s}}/coach/003cX000008IZnXQAW/stats",
+							"host": [
+								"{{base_url_s}}"
+							],
+							"path": [
+								"coach",
+								"003cX000008IZnXQAW",
+								"stats"
+							]
+						},
+						"description": "Response Example:\n\n{ \"Not Started\": 1, \"Started\": 0, \"Complete\": 41}"
+					},
+					"response": []
 				}
 			]
 		},
@@ -2238,40 +2272,6 @@
 							]
 						},
 						"description": "BODY/JSON:\n\n{  \n\"TeamSeasonName\": \"\",  \n\"TeamId\": \"\",  \n\"SeasonId\": \"\",  \n\"SchoolSite\": \"\",  \n\"Partnership\": \"\",  \n\"TotalNoOfPlayers\": 0,  \n\"TotalNoOfSessions\": 0,  \n\"SeasonStartDate\": \"\",  \n\"SeasonEndDate\": \"\",  \n\"CoachSoccer\": \"\",  \n\"CoachWriting\": \"\",  \n\"ProgramCoordinator\": \"\",  \n\"ProgramManager\": \"\"  \n}"
-					},
-					"response": []
-				},
-				{
-					"name": "/tasks/{coachId}/stats",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "client_id",
-								"value": "{{sandbox_client_id}}"
-							},
-							{
-								"key": "client_secret",
-								"value": "{{sandbox_client_secret}}"
-							},
-							{
-								"key": "Origin",
-								"value": "Postman",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{base_url_s}}/tasks/003cX000008IZnXQAW/stats",
-							"host": [
-								"{{base_url_s}}"
-							],
-							"path": [
-								"tasks",
-								"003cX000008IZnXQAW",
-								"stats"
-							]
-						},
-						"description": "Response Example:\n\n{ \"Not Started\": 1, \"Started\": 0, \"Complete\": 41}"
 					},
 					"response": []
 				},

--- a/docs/Scores - Salesforce Data API.postman_collection.json
+++ b/docs/Scores - Salesforce Data API.postman_collection.json
@@ -2010,7 +2010,7 @@
 					"response": []
 				},
 				{
-					"name": "/coach/{coachId}/stats",
+					"name": "/coach/{teamSeasonId}/{coachId}/stats",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -2029,12 +2029,13 @@
 							}
 						],
 						"url": {
-							"raw": "{{base_url_s}}/coach/003cX000008IZnXQAW/stats",
+							"raw": "{{base_url_s}}/coach/a0qcX000000GEggQAG/003cX000008IZnXQAW/stats",
 							"host": [
 								"{{base_url_s}}"
 							],
 							"path": [
 								"coach",
+								"a0qcX000000GEggQAG",
 								"003cX000008IZnXQAW",
 								"stats"
 							]

--- a/docs/Scores - Salesforce Data API.postman_collection.json
+++ b/docs/Scores - Salesforce Data API.postman_collection.json
@@ -2010,7 +2010,7 @@
 					"response": []
 				},
 				{
-					"name": "/coach/{teamSeasonId}/{coachId}/stats",
+					"name": "/coach/{coachId}/teamseasons/{teamSeasonId}/stats",
 					"request": {
 						"method": "GET",
 						"header": [

--- a/docs/Scores - Salesforce Data API.postman_collection.json
+++ b/docs/Scores - Salesforce Data API.postman_collection.json
@@ -2438,6 +2438,34 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Execute Custom Script",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"scriptName\": \"example-script\",\n    \"parameters\": {\n        \"param1\": \"value1\",\n        \"param2\": \"value2\"\n    }\n}"
+				},
+				"url": {
+					"raw": "{{base_url}}/scripts/custom",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"scripts",
+						"custom"
+					]
+				},
+				"description": "Execute a custom script with parameters"
+			},
+			"response": []
 		}
 	],
 	"event": [

--- a/docs/attendance-task-create.py
+++ b/docs/attendance-task-create.py
@@ -1,0 +1,75 @@
+import csv
+import asyncio
+import aiohttp
+import ssl
+
+ssl_context = ssl.create_default_context()
+ssl_context.check_hostname = False
+ssl_context.verify_mode = ssl.CERT_NONE
+
+with open('./data/attendance-task/results.csv', newline='') as csvfile:
+    reader = csv.reader(csvfile)
+    counter = 0
+    total_coutner = 0
+    memo = {}
+    for row in reader:
+        if total_coutner == 0:
+            total_coutner += 1
+            continue
+
+        sessionId = row[0]
+        if sessionId == "a0pcX0000005lZNQAY":
+            continue
+        coach1 = row[4]
+        coach2 = row[5]
+        attendanceDate = row[6]
+        memo[sessionId] = (coach1, coach2, attendanceDate)
+
+        total_coutner += 1
+
+
+    # reader = csv.reader(csvfile)
+    # print(f"Total coach mismatches: {counter}")
+    # print(f"Total records: {total_coutner}")
+    async def send_post_request(http_session, session, coach, endOfTeamSeason):
+        url = "https://localhost:8091/api/tasks"
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        payload = {
+                "AssignedBy": "",
+                "AssignedTo": coach,
+                "CreatedByContact": "0051T000009eHfvQAE",
+                "CreatedContact": "",
+                "LastModifiedBy": "0051T000009eHfvQAE",
+                "LastModifiedContact": "",
+                "OwnerId": "0051T000009eHfvQAE",
+                "DueDate": endOfTeamSeason,
+                "Session": session,
+                "Name": "Catch-up attendance",
+                "TaskStatus": "To Do",
+                "TaskType": "Take Attendance"
+            }
+
+        try:
+            async with http_session.post(url, headers=headers, json=payload, ssl=ssl_context) as response:
+                return await response.text(), response.status
+        except Exception as e:
+            print(e)
+            return None, None
+
+    async def main():
+        async with aiohttp.ClientSession() as http_session:
+            for session_id, (coach1, coach2, end_of_team_season) in memo.items():
+                print(f"Processing session {session_id} with coaches {coach1} and {coach2} ({end_of_team_season})")
+                if coach1 == coach2:
+                    resp = await send_post_request(http_session, session_id, coach1, end_of_team_season)
+                    print(resp)
+                else:
+                    resp1 = await send_post_request(http_session, session_id, coach1, end_of_team_season)
+                    print(resp1)
+                    resp2 = await send_post_request(http_session, session_id, coach2, end_of_team_season)
+                    print(resp2)
+                print(f"------------------------------------------------------------------------------------------")
+
+    asyncio.run(main())

--- a/docs/data/attendance-task/query.txt
+++ b/docs/data/attendance-task/query.txt
@@ -1,0 +1,14 @@
+SELECT
+    Id,
+    Session_Date__c,
+    Team_Season__c,
+    Session_Topic__c,
+    Team_Season__r.Coach_Soccer__c,
+    Team_Season__r.Coach_Writing__c
+FROM Session__c
+WHERE
+    Session_Date__c >= 2025-01-01 AND
+    Id NOT IN (
+        SELECT Session__c
+        FROM SCORES_Task__c
+    )

--- a/docs/data/attendance-task/results.csv
+++ b/docs/data/attendance-task/results.csv
@@ -1,0 +1,2 @@
+"Id","Session_Date__c","Team_Season__c","Session_Topic__c","Team_Season__r.Coach_Soccer__c","Team_Season__r.Coach_Writing__c","Team_Season__r.Season_End_Date__c"
+"a0pcX0000005lZNQA2","2026-09-23","a0qcX000000GEggQA2","Soccer","003Hs00004W5kzXIA2","003cX000005TYcvQA2","2025-06-21"

--- a/docs/sessions-no-results.py
+++ b/docs/sessions-no-results.py
@@ -1,0 +1,26 @@
+import csv
+
+memo_true = set()
+with open('./data/sessions-from-attendances/true.csv', newline='') as csvfile:
+    reader = csv.reader(csvfile)
+    for row in reader:
+        memo_true.add(row[0])
+
+
+memo_false = set()
+with open('./data/sessions-from-attendances/false.csv', newline='') as csvfile:
+    reader = csv.reader(csvfile)
+    for row in reader:
+        memo_false.add(row[0])
+
+print(len(memo_false))
+print(len(memo_true))
+result = []
+for item in memo_false:
+    if item in memo_true:
+        continue
+    else:
+        result.append(item)
+
+print(len(result))
+print(result)

--- a/scripts/exchange-update.py
+++ b/scripts/exchange-update.py
@@ -351,6 +351,11 @@ if __name__ == "__main__":
         identical, details = are_files_identical("salesforce-data-api.zip", "new_salesforce-data-api.zip", ignore_list=ignore_patterns)
         if identical:
             print("Files are identical. No need to upload asset.")
+            if change_api_specification(latest_version, token):
+                print("API specification updated successfully.")
+            else:
+                print("Failed to update API specification.")
+                exit(1)
             print("=======================================")
             print("  SUCCESS: Asset updated successfully")
             print("=======================================")

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -150,6 +150,7 @@ payload map ( payload01 ,
 				<ee:set-variable variableName="teamSeasonId"><![CDATA[attributes.uriParams.'teamSeasonId']]></ee:set-variable>
 			</ee:variables>
 		</ee:transform>
+		<set-variable value='#[%dw 2.0&#10;var startDateCond =    if (!isEmpty(attributes.queryParams.startDate)) &#10;        " AND Session_Date__c &gt;= " ++ (attributes.queryParams.startDate as Date)&#10;    else ""&#10;&#10;var endDateCond = &#10;    if (!isEmpty(attributes.queryParams.endDate)) &#10;        " AND Session_Date__c &lt;= " ++ (attributes.queryParams.endDate as Date)&#10;    else ""&#10;output text/plain&#10;---&#10;startDateCond ++ endDateCond]' doc:name='Set Variable "dateQuery"' doc:id="a615ab70-d45d-4622-8cb8-cfdf865b383e" variableName="dateQuery"/>
 		<logger
 			level="INFO"
 			doc:name="Log Stored URI Params"
@@ -191,12 +192,14 @@ payload map ( payload01 ,
 					OR Team_Season__r.SCORES_Program_Coordinator__c = ':coachid' 
 					OR Team_Season__r.SCORES_Program_Manager__c = ':coachid'
 					)
+					:dateQuery
 			]]></salesforce:salesforce-query>
 			<salesforce:parameters><![CDATA[#[output application/java
 ---
 {
 	teamseasonid : vars.teamSeasonId,
-	coachid : vars.coachId
+	coachid : vars.coachId,
+	dateQuery : vars.dateQuery
 }]]]></salesforce:parameters>
 		</salesforce:query>
 		<ee:transform

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1359,7 +1359,7 @@ output application/json
 			</ee:message>
 		</ee:transform>
 	</flow>
-	<flow name="get:\coach\(teamSeasonId)\(coachId)\stats" doc:id="59de02c6-9de9-4b00-9b6c-f7af6438b90e" >
+	<flow name="get:\coach\(coachId)\teamseasons\(teamSeasonId)\stats" doc:id="59de02c6-9de9-4b00-9b6c-f7af6438b90e" >
 		<set-variable value="#[attributes.uriParams.'coachId']" doc:name='Save "coachId"' doc:id="66df3a39-36f9-4328-81d5-ed4a29902fb1" variableName="coachId" />
 		<set-variable value="#[attributes.uriParams.'teamSeasonId']" doc:name='Save "teamSeasonId"' doc:id="477fb233-3b92-4da4-b1c3-8300ce9323ee" variableName="teamSeasonId" />
 		<set-variable value='#[%dw 2.0&#10;import * from dw::core::Dates&#10;&#10;output application/json&#10;var first = atBeginningOfMonth(now()) as Date&#10;var last = (atBeginningOfMonth(now() + |P1M|) - |P1D|) as Date&#10;&#10;output application/json&#10;---&#10;{&#10;    "firstDay": first,&#10;    "lastDay": last&#10;}]' doc:name="Set Month Dates" doc:id="59c93df1-71bb-4dc5-8f4a-1622673783c8" variableName="currentMonth"/>

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1388,11 +1388,32 @@ AND Session__r.Team_Season__c = ':teamSeasonId']]></salesforce:salesforce-query>
 	teamSeasonId: vars.teamSeasonId
 }]]]></salesforce:parameters>
 		</salesforce:query>
+		<salesforce:query doc:name="Query to retrieve attendance records for particular coach and teamseason" doc:id="9eba5095-dd10-4ee1-a117-d1e0cee3e90f" config-ref="Salesforce_Config" target="totalAttendancesThisTeamseason">
+			<salesforce:salesforce-query><![CDATA[SELECT Attended__c,Id,Session__c, Session__r.Team_Season__c, Session__r.Team_Season__r.Coach_Soccer__c, Session__r.Team_Season__r.Coach_Writing__c 
+FROM Attendance__c
+WHERE Session__r.Team_Season__c = ':teamSeasonId'
+AND 
+(Session__r.Team_Season__r.Coach_Writing__c = ':coachId' OR Session__r.Team_Season__r.Coach_Soccer__c = ':coachId')]]></salesforce:salesforce-query>
+			<salesforce:parameters><![CDATA[#[output application/java
+				---
+{
+	coachId: vars.coachId,
+	teamSeasonId: vars.teamSeasonId
+}]]]></salesforce:parameters>
+		</salesforce:query>
 		<ee:transform doc:name="Prepare Response" doc:id="2a9bf057-e618-4767-8d9f-ac63a99127fc">
 			<ee:message>
 				<ee:set-payload><![CDATA[%dw 2.0
 var rightNow = (now() >> "America/Los_Angeles") as LocalDateTime
 
+var true_attendances = sizeOf(vars.totalAttendancesThisTeamseason filter (item, i) -> item.Attended__c == "true") default 0
+var total_attendances = sizeOf(vars.totalAttendancesThisTeamseason) default 1
+var attendances_ratio = 
+    if (total_attendances != 0) 
+        ((true_attendances as Number / total_attendances) * 100)
+        as String {format: "##0.00", roundMode: "HALF_UP"} ++ "%" 
+    else "0%"
+    
 output application/json
 ---
 {
@@ -1407,8 +1428,12 @@ output application/json
 			"done": sizeOf(vars.totalTasksThisTeamSeason filter (item, i) -> item.Task_Status__c == "Done"),
 			"total": sizeOf(vars.totalTasksThisTeamSeason) default 0
 		}
+	},
+	"attendances":{
+		"current_teamseason_ratio": attendances_ratio
 	}
-}]]></ee:set-payload>
+}
+]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
 		<!-- [STUDIO:"Query to gather stats based on &quot;coachId&quot;"]<salesforce:query doc:name='Query to gather stats based on "coachId"' doc:id="4495ba6e-b4ac-4345-a66e-f1d783fe6db1" config-ref="Salesforce_Config" target="availableStats" >

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1378,6 +1378,27 @@ AND (Session_Date__c >= :firstDay AND Session_Date__c <= :lastDay)]]></salesforc
 }]]]></salesforce:parameters>
 		</salesforce:query>
 		<set-variable value='#[%dw 2.0&#10;output application/json&#10;---&#10;vars.totalSessionsThisMonth map (item, i) -&gt; &#10;item ++ {&#10;        "Session_DateTime": &#10;        (item.Session_Date__c ++ "T" ++ item.Session_End__c) &#10;        as DateTime&#10;  }]' doc:name='Set Variable "totalSessionsThisMonth" with a combined DateTime field' doc:id="d7f2b182-afb9-4a4e-8dfa-70e2fa4b5b3e" variableName="totalSessionsThisMonth"/>
+		<salesforce:query doc:name="Query to retrieve total tasks overall" doc:id="8af0615e-b248-45f9-a01f-690ea9dfafcc" config-ref="Salesforce_Config" target="totalTasksOverall">
+			<salesforce:salesforce-query><![CDATA[SELECT COUNT()
+FROM SCORES_Task__c 
+WHERE Assigned_To__c = ':coachId']]></salesforce:salesforce-query>
+			<salesforce:parameters><![CDATA[#[output application/java
+				---
+{
+	coachId: vars.coachId
+}]]]></salesforce:parameters>
+		</salesforce:query>
+		<salesforce:query doc:name='Query to retrieve total tasks overall marked as "Done"' doc:id="4f648ab5-a088-4a54-bde3-32688cad8aa6" config-ref="Salesforce_Config" target="totalTasksOverallDone">
+			<salesforce:salesforce-query><![CDATA[SELECT COUNT()
+FROM SCORES_Task__c 
+WHERE Assigned_To__c = ':coachId'
+AND Task_Status__c = 'Done']]></salesforce:salesforce-query>
+			<salesforce:parameters><![CDATA[#[output application/java
+				---
+{
+	coachId: vars.coachId
+}]]]></salesforce:parameters>
+		</salesforce:query>
 		<salesforce:query doc:name="Query to retrieve total tasks for this teamseason" doc:id="e4d8d4ab-b728-442e-a74e-2e32995f7598" config-ref="Salesforce_Config" target="totalTasksThisTeamSeason">
 			<salesforce:salesforce-query><![CDATA[SELECT 
 Id, Assigned_To__c, Session__c, Session__r.Team_Season__c, Task_Status__c
@@ -1427,6 +1448,10 @@ output application/json
 		}
 	},
 	"tasks": {
+		"overall": {
+			"done": sizeOf(vars.totalTasksOverallDone) default 0,
+			"total": sizeOf(vars.totalTasksOverall) default 0
+		},
 		"current_teamseason": {
 			"done": sizeOf(vars.totalTasksThisTeamSeason filter (item, i) -> item.Task_Status__c == "Done"),
 			"total": sizeOf(vars.totalTasksThisTeamSeason) default 0

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1356,8 +1356,9 @@ output application/json
 			</ee:message>
 		</ee:transform>
 	</flow>
-	<flow name="get:\coach\(coachId)\stats" doc:id="59de02c6-9de9-4b00-9b6c-f7af6438b90e" >
+	<flow name="get:\coach\(teamSeasonId)\(coachId)\stats" doc:id="59de02c6-9de9-4b00-9b6c-f7af6438b90e" >
 		<set-variable value="#[attributes.uriParams.'coachId']" doc:name='Save "coachId"' doc:id="66df3a39-36f9-4328-81d5-ed4a29902fb1" variableName="coachId" />
+		<set-variable value="#[attributes.uriParams.'teamSeasonId']" doc:name='Save "teamSeasonId"' doc:id="477fb233-3b92-4da4-b1c3-8300ce9323ee" variableName="teamSeasonId" />
 		<set-variable value='#[%dw 2.0&#10;import * from dw::core::Dates&#10;&#10;output application/json&#10;var first = atBeginningOfMonth(now()) as Date&#10;var last = (atBeginningOfMonth(now() + |P1M|) - |P1D|) as Date&#10;&#10;output application/json&#10;---&#10;{&#10;    "firstDay": first,&#10;    "lastDay": last&#10;}]' doc:name="Set Month Dates" doc:id="59c93df1-71bb-4dc5-8f4a-1622673783c8" variableName="currentMonth"/>
 		<salesforce:query doc:name="Query to retrieve total number of sessions this month" doc:id="df72a5a4-d117-4e5d-94ca-33372e77bbec" config-ref="Salesforce_Config" target="totalSessionsThisMonth">
 			<salesforce:salesforce-query ><![CDATA[SELECT 
@@ -1374,6 +1375,19 @@ AND (Session_Date__c >= :firstDay AND Session_Date__c <= :lastDay)]]></salesforc
 }]]]></salesforce:parameters>
 		</salesforce:query>
 		<set-variable value='#[%dw 2.0&#10;output application/json&#10;---&#10;vars.totalSessionsThisMonth map (item, i) -&gt; &#10;item ++ {&#10;        "Session_DateTime": &#10;        (item.Session_Date__c ++ "T" ++ item.Session_End__c) &#10;        as DateTime&#10;  }]' doc:name='Set Variable "totalSessionsThisMonth" with a combined DateTime field' doc:id="d7f2b182-afb9-4a4e-8dfa-70e2fa4b5b3e" variableName="totalSessionsThisMonth"/>
+		<salesforce:query doc:name="Query to retrieve total tasks for this teamseason" doc:id="e4d8d4ab-b728-442e-a74e-2e32995f7598" config-ref="Salesforce_Config" target="totalTasksThisTeamSeason">
+			<salesforce:salesforce-query><![CDATA[SELECT 
+Id, Assigned_To__c, Session__c, Session__r.Team_Season__c, Task_Status__c
+FROM SCORES_Task__c 
+WHERE Assigned_To__c = ':coachId'
+AND Session__r.Team_Season__c = ':teamSeasonId']]></salesforce:salesforce-query>
+			<salesforce:parameters><![CDATA[#[output application/java
+				---
+{
+	coachId: vars.coachId,
+	teamSeasonId: vars.teamSeasonId
+}]]]></salesforce:parameters>
+		</salesforce:query>
 		<ee:transform doc:name="Prepare Response" doc:id="2a9bf057-e618-4767-8d9f-ac63a99127fc">
 			<ee:message>
 				<ee:set-payload><![CDATA[%dw 2.0
@@ -1383,9 +1397,15 @@ output application/json
 ---
 {
 	"sessions": {
-		"month":{ 
+		"current_month":{ 
 			"completed": sizeOf(vars.totalSessionsThisMonth filter (item, i) -> (item.Session_DateTime) <= rightNow) default 0,
-			total: sizeOf(vars.totalSessionsThisMonth) default 0
+			"total": sizeOf(vars.totalSessionsThisMonth) default 0
+		}
+	},
+	"tasks": {
+		"current_teamseason": {
+			"done": sizeOf(vars.totalTasksThisTeamSeason filter (item, i) -> item.Task_Status__c == "Done"),
+			"total": sizeOf(vars.totalTasksThisTeamSeason) default 0
 		}
 	}
 }]]></ee:set-payload>

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1407,12 +1407,12 @@ AND
 var rightNow = (now() >> "America/Los_Angeles") as LocalDateTime
 
 var true_attendances = sizeOf(vars.totalAttendancesThisTeamseason filter (item, i) -> item.Attended__c == "true") default 0
-var total_attendances = sizeOf(vars.totalAttendancesThisTeamseason) default 1
+var total_attendances = sizeOf(vars.totalAttendancesThisTeamseason) default 0
 var attendances_ratio = 
     if (total_attendances != 0) 
         ((true_attendances as Number / total_attendances) * 100)
         as String {format: "##0.00", roundMode: "HALF_UP"} ++ "%" 
-    else "0%"
+    else "100%"
     
 output application/json
 ---

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1358,40 +1358,73 @@ output application/json
 	</flow>
 	<flow name="get:\coach\(coachId)\stats" doc:id="59de02c6-9de9-4b00-9b6c-f7af6438b90e" >
 		<set-variable value="#[attributes.uriParams.'coachId']" doc:name='Save "coachId"' doc:id="66df3a39-36f9-4328-81d5-ed4a29902fb1" variableName="coachId" />
-		<salesforce:query doc:name='Query to gather stats based on "coachId"' doc:id="4495ba6e-b4ac-4345-a66e-f1d783fe6db1" config-ref="Salesforce_Config" target="availableStats" >
-			<salesforce:salesforce-query ><![CDATA[SELECT Task_Status__c, COUNT(Id)
-FROM SCORES_Task__c
-WHERE Assigned_To__c = ':coachId'
-GROUP BY Task_Status__c]]></salesforce:salesforce-query>
+		<set-variable value='#[%dw 2.0&#10;import * from dw::core::Dates&#10;&#10;output application/json&#10;var first = atBeginningOfMonth(now()) as Date&#10;var last = (atBeginningOfMonth(now() + |P1M|) - |P1D|) as Date&#10;&#10;output application/json&#10;---&#10;{&#10;    "firstDay": first,&#10;    "lastDay": last&#10;}]' doc:name="Set Month Dates" doc:id="59c93df1-71bb-4dc5-8f4a-1622673783c8" variableName="currentMonth"/>
+		<salesforce:query doc:name="Query to retrieve total number of sessions this month" doc:id="df72a5a4-d117-4e5d-94ca-33372e77bbec" config-ref="Salesforce_Config" target="totalSessionsThisMonth">
+			<salesforce:salesforce-query ><![CDATA[SELECT 
+Id, Team_Season__r.Coach_Soccer__c, Team_Season__r.Coach_Writing__c, Session_Date__c, Session_End__c
+FROM Session__c
+WHERE (Team_Season__r.Coach_Writing__c = ':coachId' OR Team_Season__r.Coach_Soccer__c = ':coachId')
+AND (Session_Date__c >= :firstDay AND Session_Date__c <= :lastDay)]]></salesforce:salesforce-query>
 			<salesforce:parameters ><![CDATA[#[output application/java
 				---
 {
 	coachId: vars.coachId,
+	firstDay: vars.currentMonth.firstDay,
+	lastDay: vars.currentMonth.firstDay
 }]]]></salesforce:parameters>
 		</salesforce:query>
-		<salesforce:describe-sobject type="SCORES_Task__c" doc:name="Get SCORES_Task__c properties (Describe sobject)" doc:id="aa3fb261-8e5f-4771-8d40-10573952c376" config-ref="Salesforce_Config" />
-		<ee:transform doc:name='Filter "Task_Status__c" values' doc:id="adfe6d6d-fe2e-4bb6-9a66-67008c63ba80" >
+		<set-variable value='#[%dw 2.0&#10;output application/json&#10;---&#10;vars.totalSessionsThisMonth map (item, i) -&gt; &#10;item ++ {&#10;        "Session_DateTime": &#10;        (item.Session_Date__c ++ "T" ++ item.Session_End__c) &#10;        as DateTime&#10;  }]' doc:name='Set Variable "totalSessionsThisMonth" with a combined DateTime field' doc:id="d7f2b182-afb9-4a4e-8dfa-70e2fa4b5b3e" variableName="totalSessionsThisMonth"/>
+		<ee:transform doc:name="Prepare Response" doc:id="2a9bf057-e618-4767-8d9f-ac63a99127fc">
+			<ee:message>
+				<ee:set-payload><![CDATA[%dw 2.0
+var rightNow = (now() >> "America/Los_Angeles") as LocalDateTime
+
+output application/json
+---
+{
+	"sessions": {
+		"month":{ 
+			"completed": sizeOf(vars.totalSessionsThisMonth filter (item, i) -> (item.Session_DateTime) <= rightNow) default 0,
+			total: sizeOf(vars.totalSessionsThisMonth) default 0
+		}
+	}
+}]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<!-- [STUDIO:"Query to gather stats based on &quot;coachId&quot;"]<salesforce:query doc:name='Query to gather stats based on "coachId"' doc:id="4495ba6e-b4ac-4345-a66e-f1d783fe6db1" config-ref="Salesforce_Config" target="availableStats" >
+			<salesforce:salesforce-query ><![CDATA[SELECT Task_Status__c, COUNT(Id)
+FROM SCORES_Task__c
+WHERE Assigned_To__c = ':coachId'
+GROUP BY Task_Status__c&#93;&#93;></salesforce:salesforce-query>
+			<salesforce:parameters ><![CDATA[#[output application/java
+				&#45;&#45;-
+{
+	coachId: vars.coachId,
+}&#93;&#93;&#93;></salesforce:parameters>
+		</salesforce:query> [STUDIO] -->
+		<!-- [STUDIO:"Get SCORES_Task__c properties (Describe sobject)"]<salesforce:describe-sobject type="SCORES_Task__c" doc:name="Get SCORES_Task__c properties (Describe sobject)" doc:id="aa3fb261-8e5f-4771-8d40-10573952c376" config-ref="Salesforce_Config" /> [STUDIO] -->
+		<!-- [STUDIO:"Filter &quot;Task_Status__c&quot; values"]<ee:transform doc:name='Filter "Task_Status__c" values' doc:id="adfe6d6d-fe2e-4bb6-9a66-67008c63ba80" >
 			<ee:message >
 				<ee:set-payload ><![CDATA[%dw 2.0
 output application/json
----
+&#45;&#45;-
 (
     payload.fields 
         filter (field) -> field.name == "Task_Status__c"
-)[0].picklistValues 
-    map (item) -> item.value]]></ee:set-payload>
+)[0&#93;.picklistValues 
+    map (item) -> item.value&#93;&#93;></ee:set-payload>
 			</ee:message>
-		</ee:transform>
-		<ee:transform doc:name="Prepare Stats" doc:id="edf8e8cd-aa0d-4693-9799-b8a43616dafd" >
+		</ee:transform> [STUDIO] -->
+		<!-- [STUDIO:"Prepare Stats"]<ee:transform doc:name="Prepare Stats" doc:id="edf8e8cd-aa0d-4693-9799-b8a43616dafd" >
 			<ee:message >
 				<ee:set-payload ><![CDATA[%dw 2.0
 output application/json
 var memo = vars.availableStats reduce (item, acc = {}) -> 
   acc ++ {(item.Task_Status__c): item.expr0}
-var result = payload map ((item, index) -> {(item): memo[item] default 0})
----
-result reduce ((item, acc = {}) -> acc ++ item)]]></ee:set-payload>
+var result = payload map ((item, index) -> {(item): memo[item&#93; default 0})
+&#45;&#45;-
+result reduce ((item, acc = {}) -> acc ++ item)&#93;&#93;></ee:set-payload>
 			</ee:message>
-		</ee:transform>
+		</ee:transform> [STUDIO] -->
 	</flow>
 </mule>

--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -1356,4 +1356,42 @@ output application/json
 			</ee:message>
 		</ee:transform>
 	</flow>
+	<flow name="get:\coach\(coachId)\stats" doc:id="59de02c6-9de9-4b00-9b6c-f7af6438b90e" >
+		<set-variable value="#[attributes.uriParams.'coachId']" doc:name='Save "coachId"' doc:id="66df3a39-36f9-4328-81d5-ed4a29902fb1" variableName="coachId" />
+		<salesforce:query doc:name='Query to gather stats based on "coachId"' doc:id="4495ba6e-b4ac-4345-a66e-f1d783fe6db1" config-ref="Salesforce_Config" target="availableStats" >
+			<salesforce:salesforce-query ><![CDATA[SELECT Task_Status__c, COUNT(Id)
+FROM SCORES_Task__c
+WHERE Assigned_To__c = ':coachId'
+GROUP BY Task_Status__c]]></salesforce:salesforce-query>
+			<salesforce:parameters ><![CDATA[#[output application/java
+				---
+{
+	coachId: vars.coachId,
+}]]]></salesforce:parameters>
+		</salesforce:query>
+		<salesforce:describe-sobject type="SCORES_Task__c" doc:name="Get SCORES_Task__c properties (Describe sobject)" doc:id="aa3fb261-8e5f-4771-8d40-10573952c376" config-ref="Salesforce_Config" />
+		<ee:transform doc:name='Filter "Task_Status__c" values' doc:id="adfe6d6d-fe2e-4bb6-9a66-67008c63ba80" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+(
+    payload.fields 
+        filter (field) -> field.name == "Task_Status__c"
+)[0].picklistValues 
+    map (item) -> item.value]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<ee:transform doc:name="Prepare Stats" doc:id="edf8e8cd-aa0d-4693-9799-b8a43616dafd" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+var memo = vars.availableStats reduce (item, acc = {}) -> 
+  acc ++ {(item.Task_Status__c): item.expr0}
+var result = payload map ((item, index) -> {(item): memo[item] default 0})
+---
+result reduce ((item, acc = {}) -> acc ++ item)]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+	</flow>
 </mule>

--- a/src/main/mule/main-api.xml
+++ b/src/main/mule/main-api.xml
@@ -242,6 +242,7 @@
 			                text: "🚨 *Error Notification* 🚨\n"
 			                   ++ "*Environment:* " ++ p('env') ++ "\n" 
 			                   ++ "*Source of Request:* " ++ (if (platform != null and buildVersion != null) (origin ++ " [" ++ platform ++ ", " ++ buildVersion ++ "]") else origin) ++ "\n"
+			   			       ++ "*Firebase ID:* " ++ (vars.originalAttributes.headers.'X-Firebase-UID' default "N/A") ++ "\n"
 			                   ++ "*Endpoint:* `" ++ (vars.originalAttributes.method default "N/A") ++ " " ++ (vars.originalAttributes.maskedRequestPath default "N/A") ++ "`\n"
 			                   ++ "*Query Parameters:* " ++ (vars.originalAttributes.queryString default "N/A") ++ "\n"
 			                   ++ "*Timestamp (PT):* " ++ (format(now() >> "America/Los_Angeles"))

--- a/src/main/mule/scripts.xml
+++ b/src/main/mule/scripts.xml
@@ -1,5 +1,177 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/salesforce/current/mule-salesforce.xsd">
 	
+	<flow name="createTasksForAllSessionsWithNoTasksSinceJan2025" doc:id="e684ebc1-d149-4d36-b9ef-9da77a3dba97" >
+		<salesforce:query doc:name="Get All Records" doc:id="2d2b305d-607a-4ca1-8249-3f07c534d1e9" config-ref="Salesforce_Config">
+					<salesforce:salesforce-query><![CDATA[SELECT
+    Id, 
+    Session_Date__c,
+    Team_Season__c, 
+    Session_Topic__c,
+    Team_Season__r.Coach_Soccer__c, 
+    Team_Season__r.Coach_Writing__c,
+    Team_Season__r.Season_End_Date__c
+FROM Session__c
+WHERE 
+    Session_Date__c >= 2025-01-01 
+AND 
+    Id NOT IN (
+        SELECT Session__c 
+        FROM SCORES_Task__c
+    )
+AND (Team_Season__r.Coach_Soccer__c != null OR Team_Season__r.Coach_Writing__c != null)]]></salesforce:salesforce-query>
+				</salesforce:query>
+		<ee:transform doc:name="Transform Message" doc:id="eb80625b-935f-4501-8ee9-bc845ab52d46">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+payload]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+		<foreach doc:name="For Each" doc:id="878c5292-91b6-4ced-bc35-cdcefb02286f" collection="#[payload]">
+					<set-variable value="#[%dw 2.0&#10;output application/json&#10;---&#10;payload]" doc:name="Set Current Item" doc:id="d78e7d38-c6dd-4eb8-8ab7-9d99f1c96964" variableName="currentItem" />
+					<salesforce:query doc:name="Retrieve Related Attendance Records" doc:id="0453e8a8-95a5-4311-a6a0-fa7671b234bb" config-ref="Salesforce_Config">
+						<salesforce:salesforce-query><![CDATA[SELECT Attended__c FROM Attendance__c WHERE Session__c = ':session']]></salesforce:salesforce-query>
+						<salesforce:parameters><![CDATA[#[output application/java
+---
+{
+	"session" : payload.Id
+}]]]></salesforce:parameters>
+					</salesforce:query>
+					<ee:transform doc:name="Transform To JSON" doc:id="374c2a49-b3f3-49f6-b5c4-8e36534ed936">
+						<ee:message>
+							<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+payload]]></ee:set-payload>
+						</ee:message>
+					</ee:transform>
+					<set-variable value="#[payload]" doc:name="Set Attendance Records" doc:id="f5b04bdf-b8db-4eb3-86d7-55942d34d3e5" variableName="attendanceRecords" />
+					<ee:transform doc:name="Count Attendence Records Marked as True" doc:id="a5699023-b994-4f38-ae72-c5720e4066b1">
+						<ee:message>
+							<ee:set-payload><![CDATA[%dw 2.0
+var trues = vars.attendanceRecords filter (item, it) -> (item.Attended__c as Boolean == true)
+
+output application/json
+---
+sizeOf(trues)]]></ee:set-payload>
+						</ee:message>
+					</ee:transform>
+					<set-variable value="#[payload]" doc:name="Set Attendance Records Length" doc:id="2a6624d3-c823-46a3-9185-1b02fcc23114" variableName="attendanceRecordsLen" />
+					<choice doc:name="attendanceRecordsLen" doc:id="3eb420c5-5171-41fa-9fd8-c144eb7833c8">
+						<when expression="#[vars.attendanceRecordsLen &gt; 1]">
+							<logger level="INFO" doc:name="Done" doc:id="5d824e03-344e-486d-ae27-21db1018ebb0" message='A task marked as "done" will be created here' />
+							<choice doc:name="Choice1" doc:id="6159faa5-5b52-494b-9b7c-cac5a79cd6a9">
+								<when expression="#[vars.currentItem.Team_Season__r.Coach_Writing__c != null]">
+									<ee:transform doc:name="Coach_Writing__c" doc:id="0c14ec08-ba6c-40e2-9ee6-659368ef52e0">
+										<ee:message>
+											<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+    "AssignedBy": "",
+    "AssignedTo": vars.currentItem.Team_Season__r.Coach_Writing__c,
+    "CreatedByContact": "0051T000009eHfvQAE",
+    "CreatedContact": "",
+    "LastModifiedBy": "0051T000009eHfvQAE",
+    "LastModifiedContact": "",
+    "OwnerId": "0051T000009eHfvQAE",
+    "DueDate": vars.currentItem.Team_Season__r.Season_End_Date__c,
+    "Session": vars.currentItem.Id,
+    "Name": "Catch-up attendance",
+    "TaskStatus": "Done",
+    "TaskType": "Take Attendance"
+}]]></ee:set-payload>
+										</ee:message>
+									</ee:transform>
+									<flow-ref doc:name="post TASKS" doc:id="5898c462-5ace-4558-8712-f1a79aab0fb0" name="post:\tasks:application\json:salesforce-data-api-config" />
+								</when>
+							</choice>
+							<choice doc:name="Choice" doc:id="82da10e1-7fdd-4a25-9fd6-47f1ce448675">
+								<when expression="#[vars.currentItem.Team_Season__r.Coach_Soccer__c != null]">
+									<ee:transform doc:name="Coach_Soccer__c" doc:id="ecb79a55-6fd8-47da-85fb-8874f92f98f2">
+								<ee:message>
+									<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+    "AssignedBy": "",
+    "AssignedTo": vars.currentItem.Team_Season__r.Coach_Soccer__c,
+    "CreatedByContact": "0051T000009eHfvQAE",
+    "CreatedContact": "",
+    "LastModifiedBy": "0051T000009eHfvQAE",
+    "LastModifiedContact": "",
+    "OwnerId": "0051T000009eHfvQAE",
+    "DueDate": vars.currentItem.Team_Season__r.Season_End_Date__c,
+    "Session": vars.currentItem.Id,
+    "Name": "Catch-up attendance",
+    "TaskStatus": "Done",
+    "TaskType": "Take Attendance"
+}]]></ee:set-payload>
+								</ee:message>
+							</ee:transform>
+									<flow-ref doc:name="post TASKS" doc:id="1066fce4-30c0-4c05-863a-ded75289b7e9" name="post:\tasks:application\json:salesforce-data-api-config" />
+								</when>
+							</choice>
+						</when>
+						<otherwise>
+							<logger level="INFO" doc:name="To Do" doc:id="0c427212-c873-420a-acf8-53e4c6d6159e" message='A task marked as "to do" will be created here' />
+							<choice doc:name="Choice" doc:id="9acbbfde-02b8-43ca-8a55-5385372d1bd7">
+								<when expression="#[vars.currentItem.Team_Season__r.Coach_Writing__c != null]">
+									<ee:transform doc:name="Coach_Writing__c" doc:id="70657783-b6e2-45a6-898a-6db806437dea">
+										<ee:message>
+											<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+    "AssignedBy": "",
+    "AssignedTo": vars.currentItem.Team_Season__r.Coach_Writing__c,
+    "CreatedByContact": "0051T000009eHfvQAE",
+    "CreatedContact": "",
+    "LastModifiedBy": "0051T000009eHfvQAE",
+    "LastModifiedContact": "",
+    "OwnerId": "0051T000009eHfvQAE",
+    "DueDate": vars.currentItem.Team_Season__r.Season_End_Date__c,
+    "Session": vars.currentItem.Id,
+    "Name": "Catch-up attendance",
+    "TaskStatus": "To Do",
+    "TaskType": "Take Attendance"
+}]]></ee:set-payload>
+										</ee:message>
+									</ee:transform>
+									<flow-ref doc:name="post TASKS" doc:id="b5fa4a42-ce66-4ea3-bede-cfdc665f4d83" name="post:\tasks:application\json:salesforce-data-api-config" />
+								</when>
+							</choice>
+							<choice doc:name="Choice1" doc:id="31755f92-c63b-441f-a63b-6f25c2f1d0a1">
+								<when expression="#[vars.currentItem.Team_Season__r.Coach_Soccer__c != null]">
+									<ee:transform doc:name="Coach_Soccer__c" doc:id="7a8fa83d-8097-4ce8-b67a-778687a582b2">
+										<ee:message>
+											<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+    "AssignedBy": "",
+    "AssignedTo": vars.currentItem.Team_Season__r.Coach_Soccer__c,
+    "CreatedByContact": "0051T000009eHfvQAE",
+    "CreatedContact": "",
+    "LastModifiedBy": "0051T000009eHfvQAE",
+    "LastModifiedContact": "",
+    "OwnerId": "0051T000009eHfvQAE",
+    "DueDate": vars.currentItem.Team_Season__r.Season_End_Date__c,
+    "Session": vars.currentItem.Id,
+    "Name": "Catch-up attendance",
+    "TaskStatus": "To Do",
+    "TaskType": "Take Attendance"
+}]]></ee:set-payload>
+										</ee:message>
+									</ee:transform>
+									<flow-ref doc:name="post TASKS" doc:id="035bdcab-0d6b-4b96-9c4b-d17fd8b6c0b6" name="post:\tasks:application\json:salesforce-data-api-config" />
+								</when>
+							</choice>
+						</otherwise>
+					</choice>
+				</foreach>
+	</flow>
 	<flow name="post:\scripts\custom:application\json:salesforce-data-api-config">
 		<choice doc:name="Choice" doc:id="5f5701a6-0392-419d-b4bb-e14fad7aeabd" >
 			<when expression='#[p("customScript") default false]'>
@@ -13,6 +185,7 @@ output application/json
 }]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
+				<!-- [STUDIO:"Flow Ref: `createTasksForAllSessionsWithNoTasksSinceJan2025`"]<flow-ref doc:name="Flow Ref: `createTasksForAllSessionsWithNoTasksSinceJan2025`" doc:id="99a66fa3-75e7-4d43-a042-c8186d984c6b" name="createTasksForAllSessionsWithNoTasksSinceJan2025" /> [STUDIO] -->
 			</when>
 			<otherwise>
 				<ee:transform doc:name="Transform Message" doc:id="1151c86d-8fe0-4c71-9713-327a0afcfb48" >

--- a/src/main/mule/scripts.xml
+++ b/src/main/mule/scripts.xml
@@ -1,0 +1,32 @@
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:salesforce="http://www.mulesoft.org/schema/mule/salesforce" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd http://www.mulesoft.org/schema/mule/salesforce http://www.mulesoft.org/schema/mule/salesforce/current/mule-salesforce.xsd">
+	
+	<flow name="post:\scripts\custom:application\json:salesforce-data-api-config">
+		<choice doc:name="Choice" doc:id="5f5701a6-0392-419d-b4bb-e14fad7aeabd" >
+			<when expression='#[p("customScript") default false]'>
+				<ee:transform doc:name="Transform Message">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+	"message": "Custom script execution is enabled."
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<otherwise>
+				<ee:transform doc:name="Transform Message" doc:id="1151c86d-8fe0-4c71-9713-327a0afcfb48" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+	"message": "Set 'customScript' to true to enable this flow."
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</otherwise>
+		</choice>
+
+	</flow>
+</mule> 

--- a/src/main/mule/tasks.xml
+++ b/src/main/mule/tasks.xml
@@ -221,44 +221,6 @@ vars.task ++ { Attendances: [] }]]></ee:set-payload>
 			</otherwise>
 		</choice>
 	</flow>
-	<flow name="get:\tasks\(coachId)\stats" doc:id="7460545c-3cf6-4ead-b850-398c204fe06b" >
-		<set-variable value="#[attributes.uriParams.'coachId']" doc:name='Save "coachId"' doc:id="3694e194-ef36-4f13-942b-a4c0c3f4e32e" variableName="coachId"/>
-		<salesforce:query doc:name='Query to gather stats based on "coachId"' doc:id="eb46a43b-fa44-4334-9db5-187bc74f87b1" config-ref="Salesforce_Config" target="availableStats">
-			<salesforce:salesforce-query ><![CDATA[SELECT Task_Status__c, COUNT(Id)
-FROM SCORES_Task__c
-WHERE Assigned_To__c = ':coachId'
-GROUP BY Task_Status__c]]></salesforce:salesforce-query>
-			<salesforce:parameters ><![CDATA[#[output application/java
-				---
-{
-	coachId: vars.coachId,
-}]]]></salesforce:parameters>
-		</salesforce:query>
-		<salesforce:describe-sobject type="SCORES_Task__c" doc:name="Get SCORES_Task__c properties (Describe sobject)" doc:id="c1c6e3fb-40db-47d4-a353-7e53fb41197a" config-ref="Salesforce_Config" />
-		<ee:transform doc:name='Filter "Task_Status__c" values' doc:id="1ef0835c-8476-4229-9f92-069900bfcbd7" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/json
----
-(
-    payload.fields 
-        filter (field) -> field.name == "Task_Status__c"
-)[0].picklistValues 
-    map (item) -> item.value]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-		<ee:transform doc:name="Prepare Stats" doc:id="5fcb5f09-d407-4c3c-ae4e-8b09c757672d" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/json
-var memo = vars.availableStats reduce (item, acc = {}) -> 
-  acc ++ {(item.Task_Status__c): item.expr0}
-var result = payload map ((item, index) -> {(item): memo[item] default 0})
----
-result reduce ((item, acc = {}) -> acc ++ item)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-	</flow>
 	<flow name="get:\tasks\(taskId)\tags:salesforce-data-api-config">
     <logger level="INFO" message="get:\tasks\(taskId)\tags:salesforce-data-api-config"></logger>
     <ee:transform doc:id="7e56aada-f163-47f0-8ffc-213f1acd09a8" doc:name="Store Query parameters">

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -1354,3 +1354,29 @@ uses:
             application/json:
               example:
                 message: Task statuses not found
+
+/scripts:
+  /custom:
+    post:
+      description: Execute a custom script
+      body:
+        application/json:
+          type: object
+          example: |
+            {
+              "scriptName": "example-script",
+              "parameters": {
+                "param1": "value1",
+                "param2": "value2"
+              }
+            }
+      responses:
+        200:
+          body:
+            application/json:
+              type: object
+              example: |
+                {
+                  "message": "Script executed successfully",
+                  "status": "success"
+                }

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -871,6 +871,20 @@ uses:
     
 
 /coach/{coachId}:
+  /stats:
+    get:
+      description: Retrieve summary statistics of SCORES tasks assigned to a specific coach, grouped by status
+      responses:
+        200:
+          body:
+            application/json:
+              type: object
+              example: |
+                {
+                  "Not Started": 1,
+                  "Started": 0,
+                  "Complete": 42
+                }
   /regions:
     get:
       displayName: Get Regions
@@ -1242,20 +1256,6 @@ uses:
           application/json:
             example:
               message: Task created
-  /{coachId}/stats:
-    get:
-      description: Retrieve summary statistics of SCORES tasks assigned to a specific coach, grouped by status
-      responses:
-        200:
-          body:
-            application/json:
-              type: object
-              example: |
-                {
-                  "Not Started": 1,
-                  "Started": 0,
-                  "Complete": 42
-                }
   /{taskId}:
     uriParameters:
       taskId:

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -869,22 +869,6 @@ uses:
             example:
               message: Bad data
     
-
-/coach/{teamSeasonId}/{coachId}:
-  /stats:
-    get:
-      description: Retrieve summary statistics of SCORES tasks assigned to a specific coach, grouped by status
-      responses:
-        200:
-          body:
-            application/json:
-              type: object
-              example: |
-                {
-                  "Not Started": 1,
-                  "Started": 0,
-                  "Complete": 42
-                }
 /coach/{coachId}:
   /regions:
     get:
@@ -995,7 +979,20 @@ uses:
             application/json:
               example:
                 message: Team-Seasons Not Found
-
+    /{teamSeasonId}/stats:
+      get:
+        description: Retrieve summary statistics of SCORES tasks assigned to a specific coach, grouped by status
+        responses:
+          200:
+            body:
+              application/json:
+                type: object
+                example: |
+                  {
+                    "Not Started": 1,
+                    "Started": 0,
+                    "Complete": 42
+                  }
     /{teamSeasonId}/sessions:
       get:
         displayName: Get Sessions

--- a/src/main/resources/api/salesforce-data-api.raml
+++ b/src/main/resources/api/salesforce-data-api.raml
@@ -870,7 +870,7 @@ uses:
               message: Bad data
     
 
-/coach/{coachId}:
+/coach/{teamSeasonId}/{coachId}:
   /stats:
     get:
       description: Retrieve summary statistics of SCORES tasks assigned to a specific coach, grouped by status
@@ -885,6 +885,7 @@ uses:
                   "Started": 0,
                   "Complete": 42
                 }
+/coach/{coachId}:
   /regions:
     get:
       displayName: Get Regions


### PR DESCRIPTION
## Key changes

1. **New header for error forwarding to understand what users experience issues: X-Firebase-UID**
<img width="472" alt="image" src="https://github.com/user-attachments/assets/db373466-9d23-4128-bed7-cf86a57a04b1" />

---

2. **New endpoint GET `/coach/{coachId}/teamseasons/{teamSeasonId}/stats`**
<img width="775" alt="image" src="https://github.com/user-attachments/assets/c04b510b-8757-4f96-8323-a64a4f814cfe" />

---

3. **`startDate` and `endDate` query parameters for GET `/coach/{coachId}/teamseasons/{teamSeasonId}/sessions` as requested by Ammar**
<img width="935" alt="image" src="https://github.com/user-attachments/assets/3af08ec2-b865-4448-8659-b4a3313ddf4a" />

---

4. **Python scripts to create tasks for sessions with no tasks**
