### PR TITLE
Add statistics per session using new fields `Count_Attendance_True__c` and `Count_Attendance_False__c`

### DIFF
--- a/src/main/mule/coach.xml
+++ b/src/main/mule/coach.xml
@@ -181,7 +181,9 @@ payload map ( payload01 ,
 				SystemModstamp,
 				Team_Season__c,
 				Session_Start__c,
-				Session_End__c 
+				Session_End__c,
+				Count_Attendance_True__c,
+				Count_Attendance_False__c
 			FROM 
 				Session__c 
 			WHERE 
@@ -208,6 +210,12 @@ payload map ( payload01 ,
 			<ee:message>
 				<ee:set-payload><![CDATA[%dw 2.0
 output application/json
+
+fun ratio(t, f): String =
+  if (t as Number + f as Number != 0)
+       ((t as Number / (t as Number + f as Number)) as Number * 100)
+            as String { format: "##0.00", roundMode: "HALF_UP" } ++ "%"
+  else "100%"
 ---
 payload map ( payload01 , indexOfPayload01 ) -> {
 	TeamSeasonId: vars.teamSeasonId,
@@ -216,7 +224,11 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 	SessionDate: payload01.Session_Date__c as String default "",
 	SessionStartTime: payload01.Session_Start__c as LocalTime as String default "",
 	SessionEndTime: payload01.Session_End__c as LocalTime as String default "",
-	SessionTopic: payload01.Session_Topic__c default ""
+	SessionTopic: payload01.Session_Topic__c default "",
+	CountAttendanceTotal: (payload01.Count_Attendance_False__c as Number + payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceTrue: (payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceFalse: (payload01.Count_Attendance_False__c as Number) as String,
+	AttendancesRatio: ratio(payload01.Count_Attendance_True__c, payload01.Count_Attendance_False__c)
 }]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
@@ -270,7 +282,9 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 						 		Session_Date__c,
 						 		Session_Start__c,
 								Session_End__c,
-						 		Number_of_Students_Present__c
+						 		Number_of_Students_Present__c,
+						 		Count_Attendance_True__c,
+								Count_Attendance_False__c
 						 	From 
 						 		Sessions__r 
 						 	WHERE 
@@ -327,7 +341,9 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 								 Session_Date__c,
 								 Session_Start__c,
 								 Session_End__c,
-								 Number_of_Students_Present__c 
+								 Number_of_Students_Present__c,
+								 Count_Attendance_True__c,
+								 Count_Attendance_False__c 
 							FROM 
 								Sessions__r 
 							WHERE 
@@ -367,6 +383,12 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<ee:message>
 				<ee:set-payload><![CDATA[%dw 2.0
 output application/json
+
+fun ratio(t, f): String =
+  if (t as Number + f as Number != 0)
+       ((t as Number / (t as Number + f as Number)) as Number * 100)
+            as String { format: "##0.00", roundMode: "HALF_UP" } ++ "%"
+  else "100%"
 ---
 payload map ( payload01 , indexOfPayload01 ) -> {
 	Enrollments: payload01.Enrollments__r map ( enrollmentsr , indexOfEnrollmentsr ) -> {
@@ -388,7 +410,11 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 		SessionStartTime: payload01.Session_Start__c as LocalTime as String default "",
 		SessionEndTime: payload01.Session_End__c as LocalTime as String default "",
 		SessionTopic: sessionsr.Session_Topic__c,
-		TotalStudentsPresent: sessionsr.Number_of_Students_Present__c
+		TotalStudentsPresent: sessionsr.Number_of_Students_Present__c,
+		CountAttendanceTotal: (sessionsr.Count_Attendance_False__c as Number + sessionsr.Count_Attendance_True__c as Number) as String,
+		CountAttendanceTrue: (sessionsr.Count_Attendance_True__c as Number) as String,
+		CountAttendanceFalse: (sessionsr.Count_Attendance_False__c as Number) as String,
+		AttendancesRatio: ratio(sessionsr.Count_Attendance_True__c, sessionsr.Count_Attendance_False__c)
 	},
 	CoachSoccer: vars.coachId,
 	CoachWriting: vars.coachId,
@@ -902,7 +928,9 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				Team_Season__r.Team__r.School_Site__r.Region__c,
 				Team_Season__r.Team__r.SCORES_Program_Type__c,
 				Team_Season__r.Team__r.Uses_Headcount__c,
-				Session_Weekday__c 
+				Session_Weekday__c,
+				Count_Attendance_True__c,
+				Count_Attendance_False__c
 			FROM 
 				Session__c 
 			WHERE 
@@ -963,7 +991,9 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				Team_Season__r.Team__r.School_Site__r.Region__c,
 				Team_Season__r.Team__r.SCORES_Program_Type__c,
 				Team_Season__r.Team__r.Uses_Headcount__c,
-				Session_Weekday__c 
+				Session_Weekday__c,
+				Count_Attendance_True__c,
+				Count_Attendance_False__c 
 			FROM 
 				Session__c 
 			WHERE 
@@ -1023,7 +1053,9 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				Team_Season__r.Team__r.School_Site__r.Region__c,
 				Team_Season__r.Team__r.SCORES_Program_Type__c,
 				Team_Season__r.Team__r.Uses_Headcount__c,
-				Session_Weekday__c 
+				Session_Weekday__c,
+				Count_Attendance_True__c,
+				Count_Attendance_False__c 
 			FROM 
 				Session__c 
 			WHERE 
@@ -1079,7 +1111,9 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				Team_Season__r.Team__r.School_Site__r.Region__c,
 				Team_Season__r.Team__r.SCORES_Program_Type__c,
 				Team_Season__r.Team__r.Uses_Headcount__c,
-				Session_Weekday__c 
+				Session_Weekday__c,
+				Count_Attendance_True__c,
+				Count_Attendance_False__c 
 			FROM 
 				Session__c 
 			WHERE 
@@ -1120,6 +1154,12 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<ee:message>
 				<ee:set-payload><![CDATA[%dw 2.0
 output application/json
+
+fun ratio(t, f): String =
+  if (t as Number + f as Number != 0)
+       ((t as Number / (t as Number + f as Number)) as Number * 100)
+            as String { format: "##0.00", roundMode: "HALF_UP" } ++ "%"
+  else "100%"
 ---
 payload map ( payload01 , indexOfPayload01 ) -> {
 	TeamSeasonId: payload01.Team_Season__c default "",
@@ -1140,7 +1180,11 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 	SeasonName: payload01.Team_Season__r.Season__r.Name default "",
 	Region: payload01.Team_Season__r.Team__r.School_Site__r.Region__c default "",
 	ProgramType: payload01.Team_Season__r.Team__r.SCORES_Program_Type__c,
-	UsesHeadcount: payload01.Team_Season__r.Team__r.Uses_Headcount__c
+	UsesHeadcount: payload01.Team_Season__r.Team__r.Uses_Headcount__c,
+	CountAttendanceTotal: (payload01.Count_Attendance_False__c as Number + payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceTrue: (payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceFalse: (payload01.Count_Attendance_False__c as Number) as String,
+	AttendancesRatio: ratio(payload01.Count_Attendance_True__c, payload01.Count_Attendance_False__c)
 }]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>

--- a/src/main/mule/sessions.xml
+++ b/src/main/mule/sessions.xml
@@ -35,7 +35,9 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 				Session_Start__c,
 				Session_End__c,
 				Session_Topic__c,
-				Team_Season__c 
+				Team_Season__c,
+				Count_Attendance_True__c,
+				Count_Attendance_False__c
 			FROM 
 				Session__c 
 			WHERE 
@@ -55,6 +57,13 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
 			<ee:message>
 				<ee:set-payload><![CDATA[%dw 2.0
 output application/json
+
+fun ratio(t, f): String =
+  if (t as Number + f as Number != 0)
+       ((t as Number / (t as Number + f as Number)) as Number * 100)
+            as String { format: "##0.00", roundMode: "HALF_UP" } ++ "%"
+  else "100%"
+  
 ---
 payload map ( payload01 , indexOfPayload01 ) -> {
 	TeamSeasonId: payload01.Team_Season__c,
@@ -63,7 +72,11 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 	SessionDate: payload01.Session_Date__c as String,
 	SessionStartTime: payload01.Session_Start__c as LocalTime as String default "",
 	SessionEndTime: payload01.Session_End__c as LocalTime as String default "",
-	SessionTopic: payload01.Session_Topic__c
+	SessionTopic: payload01.Session_Topic__c,
+	CountAttendanceTotal: (payload01.Count_Attendance_False__c as Number + payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceTrue: (payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceFalse: (payload01.Count_Attendance_False__c as Number) as String,
+	AttendancesRatio: ratio(payload01.Count_Attendance_True__c, payload01.Count_Attendance_False__c)
 }]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
@@ -104,7 +117,9 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 				Boys_Present__c,
 				Girls_Present__c,
  				Nonbinary_Present__c,
- 				Unknown_Present__c
+ 				Unknown_Present__c,
+ 				Count_Attendance_True__c,
+				Count_Attendance_False__c
 			FROM 
 				Session__c 
 			WHERE 
@@ -123,6 +138,12 @@ payload map ( payload01 , indexOfPayload01 ) -> {
 			<ee:message>
 				<ee:set-payload><![CDATA[%dw 2.0
 output application/json
+
+fun ratio(t, f): String =
+  if (t as Number + f as Number != 0)
+       ((t as Number / (t as Number + f as Number)) as Number * 100)
+            as String { format: "##0.00", roundMode: "HALF_UP" } ++ "%"
+  else "100%"
 ---
 (payload map ( payload01 , indexOfPayload01 ) -> {
  	SessionId: payload01.Id,
@@ -137,7 +158,11 @@ output application/json
 	NonbinaryPresent: payload01.Nonbinary_Present__c,
 	UnknownPresent: payload01.Unknown_Present__c,
 	UsesHeadcount: payload01.Team_Season__r.Team__r.Uses_Headcount__c,
-	ProgramType: payload01.Team_Season__r.Team__r.SCORES_Program_Type__c
+	ProgramType: payload01.Team_Season__r.Team__r.SCORES_Program_Type__c,
+	CountAttendanceTotal: (payload01.Count_Attendance_False__c as Number + payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceTrue: (payload01.Count_Attendance_True__c as Number) as String,
+	CountAttendanceFalse: (payload01.Count_Attendance_False__c as Number) as String,
+	AttendancesRatio: ratio(payload01.Count_Attendance_True__c, payload01.Count_Attendance_False__c)
 }) reduce ($$ ++ $)]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>


### PR DESCRIPTION
All tests below are done locally using **production** credentials:

1. `GET /coach/{coachId}/teamseasons/{teamSeasonId}/sessions`
<img width="657" alt="image" src="https://github.com/user-attachments/assets/135c6a13-03c5-42f4-b8c0-97c3465c1a5a" />

2. `GET /coach/{coachId}/allSessions`
<img width="657" alt="image" src="https://github.com/user-attachments/assets/5bce8744-0394-430f-9b8a-ef87e96252db" />

3. `GET /sessions/{sessionId}`
<img width="657" alt="image" src="https://github.com/user-attachments/assets/5d6b6f57-40c9-46fc-ae22-6382ebc3f5a1" />

4. `GET /coach/{coachId}/all`
<img width="799" alt="image" src="https://github.com/user-attachments/assets/56c70ae0-0a2f-4eea-bb31-1caaf61e5c15" />

5. `GET /sessions`
<img width="799" alt="image" src="https://github.com/user-attachments/assets/113ae49b-e821-4cca-a6dc-1316632bd58d" />


