### PR TITLE
Small patch: Add new session topic `Service Learning and Soccer`

### DIFF
--- a/src/main/resources/api/datatypes.raml
+++ b/src/main/resources/api/datatypes.raml
@@ -149,7 +149,7 @@ types:
         type: date-only
       SessionTopic:
         type: string
-        enum: [ "Soccer", "Writing", "Game_Day", "Soccer_and_Writing"]
+        enum: [ "Soccer", "Writing", "Game Day", "Soccer and Writing", "Service Learning", "Service Learning and Soccer"]
       TeamSeasonId:
         type: SalesforceUniqueId
       AttendanceList:
@@ -246,7 +246,7 @@ types:
         type: date-only
       SessionTopic:
         type: string
-        enum: [ "Soccer", "Writing", "Game Day", "Soccer and Writing", "Service Learning"]
+        enum: [ "Soccer", "Writing", "Game Day", "Soccer and Writing", "Service Learning", "Service Learning and Soccer"]
       TeamSeasonId:
         type: SalesforceUniqueId
     examples: !include sessioncreatemodel-examples.raml
@@ -263,7 +263,7 @@ types:
         required: false
       SessionTopic:
         type: string
-        enum: [ "Soccer", "Writing", "Game Day", "Soccer and Writing", "Service Learning"]
+        enum: [ "Soccer", "Writing", "Game Day", "Soccer and Writing", "Service Learning", "Service Learning and Soccer"]
         required: false
       TeamSeasonId:
         type: SalesforceUniqueId


### PR DESCRIPTION
Simply added a new enum to session topics: `Service Learning and Soccer`. 

Successfully tested on Sandbox:

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/533bedee-f44f-49e4-ad70-60c786e7a07a" />

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/90b79b1f-8b46-4fe7-9bb8-6b58b3db253a" />
